### PR TITLE
fix: dns verifier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "import/extensions": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "no-unused-expressions": "off"
+    "no-unused-expressions": "off",
+    "no-else-return": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/Open-Attestation/oa-verify.svg?style=svg)](https://circleci.com/gh/Open-Attestation/oa-verify)
 
-Library to verify any [OpenAttestation](https://github.com/OpenCerts/open-attestation) document. This library implements [the verifier ADR](https://github.com/Open-Attestation/adr/blob/master/verifier.md).
+Library to verify any [OpenAttestation](https://github.com/Open-Attestation/open-attestation) document. This library implements [the verifier ADR](https://github.com/Open-Attestation/adr/blob/master/verifier.md).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-cz": "^3.3.0",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
-    "semantic-release": "^15.13.31",
+    "semantic-release": "^15.14.0",
     "ts-jest": "^24.2.0",
     "typescript": "^3.7.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,5 @@ const openAttestationVerifiers: Verifier<
 
 const verify = verificationBuilder(openAttestationVerifiers);
 
+export * from "./types/core";
 export { verificationBuilder, openAttestationVerifiers, isValid, verify, Verifier };

--- a/src/verifiers/openAttestationDnsTxt.ts
+++ b/src/verifiers/openAttestationDnsTxt.ts
@@ -14,6 +14,7 @@ type Identity =
       value: string;
     };
 // Resolve identity of an issuer, currently supporting only DNS-TXT
+// DNS-TXT is explained => https://github.com/Open-Attestation/adr/blob/master/decentralized_identity_proof_DNS-TXT.md
 const resolveIssuerIdentity = async (
   issuer: v2.Issuer | v3.Issuer,
   smartContractAddress: string,

--- a/src/verifiers/openAttestationDnsTxt.ts
+++ b/src/verifiers/openAttestationDnsTxt.ts
@@ -106,29 +106,31 @@ export const openAttestationDnsTxt: Verifier<
           data: identities,
           status: "VALID"
         };
-      }
-      const documentData = getData(document);
-      const identity = await resolveIssuerIdentity(documentData.issuer, documentData.proof.value, options);
-      if (identity.status === "INVALID") {
+      } else {
+        // v3 document
+        const documentData = getData(document);
+        const identity = await resolveIssuerIdentity(documentData.issuer, documentData.proof.value, options);
+        if (identity.status === "INVALID") {
+          return {
+            name,
+            type,
+            data: {
+              type: documentData.issuer.identityProof.type,
+              location: documentData.issuer.identityProof.location,
+              value: documentData.proof.value
+            },
+            message: "Certificate issuer identity is invalid",
+            status: "INVALID"
+          };
+        }
+
         return {
           name,
           type,
-          data: {
-            type: documentData.issuer.identityProof.type,
-            location: documentData.issuer.identityProof.location,
-            value: documentData.proof.value
-          },
-          message: "Certificate issuer identity is invalid",
-          status: "INVALID"
+          data: identity,
+          status: "VALID"
         };
       }
-
-      return {
-        name,
-        type,
-        data: identity,
-        status: "VALID"
-      };
     } catch (e) {
       return {
         name,

--- a/src/verifiers/openAttestationDnsTxt.ts
+++ b/src/verifiers/openAttestationDnsTxt.ts
@@ -89,14 +89,14 @@ export const openAttestationDnsTxt: Verifier<
 
         const invalidIdentity = identities.findIndex(identity => identity.status === "INVALID");
         if (invalidIdentity !== -1) {
-          const value =
+          const smartContractAddress =
             documentData.issuers[invalidIdentity].documentStore || documentData.issuers[invalidIdentity].tokenRegistry;
 
           return {
             name,
             type,
             data: identities,
-            message: `Certificate issuer identity for ${value} is invalid`,
+            message: `Certificate issuer identity for ${smartContractAddress} is invalid`,
             status: "INVALID"
           };
         }
@@ -107,7 +107,7 @@ export const openAttestationDnsTxt: Verifier<
           status: "VALID"
         };
       } else {
-        // v3 document
+        // we have a v3 document
         const documentData = getData(document);
         const identity = await resolveIssuerIdentity(documentData.issuer, documentData.proof.value, options);
         if (identity.status === "INVALID") {

--- a/src/verifiers/openAttestationDnsTxt.v2.test.ts
+++ b/src/verifiers/openAttestationDnsTxt.v2.test.ts
@@ -1,107 +1,243 @@
 import { openAttestationDnsTxt } from "./openAttestationDnsTxt";
 import { documentRopstenValidWithToken } from "../../test/fixtures/v2/documentRopstenValidWithToken";
+import { verificationBuilder } from "./verificationBuilder";
 
+const verify = verificationBuilder([openAttestationDnsTxt]);
 describe("OpenAttestationDnsTxt v2 document", () => {
-  it("should return a valid fragment when document has valid identity", async () => {
-    const fragment = await openAttestationDnsTxt.verify(documentRopstenValidWithToken, {
-      network: "ropsten"
-    });
-    expect(fragment).toStrictEqual({
-      type: "ISSUER_IDENTITY",
-      name: "OpenAttestationDnsTxt",
-      data: [
+  describe("with one issuer", () => {
+    it("should return a valid fragment when document has valid identity", async () => {
+      const fragment = await verify(documentRopstenValidWithToken, {
+        network: "ropsten"
+      });
+      expect(fragment).toStrictEqual([
         {
-          dns: "example.tradetrust.io",
-          identified: true,
-          smartContract: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [
+            {
+              dns: "example.tradetrust.io",
+              status: "VALID",
+              value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+            }
+          ],
+          status: "VALID"
         }
-      ],
-      status: "VALID"
+      ]);
     });
-  });
-  it("should return an invalid fragment when document identity does not match", async () => {
-    const document = {
-      ...documentRopstenValidWithToken,
-      data: {
-        ...documentRopstenValidWithToken.data,
-        issuers: [
-          {
-            ...documentRopstenValidWithToken.data.issuers[0],
-            tokenRegistry: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xabcd"
-          }
-        ]
-      }
-    };
-    const fragment = await openAttestationDnsTxt.verify(document, {
-      network: "ropsten"
-    });
-    expect(fragment).toStrictEqual({
-      type: "ISSUER_IDENTITY",
-      name: "OpenAttestationDnsTxt",
-      data: { location: "example.tradetrust.io", value: "0xabcd", type: "DNS-TXT" },
-      message: "Certificate issuer identity is invalid",
-      status: "INVALID"
-    });
-  });
-  it("should return an error fragment when document has no identity type", async () => {
-    const document = {
-      ...documentRopstenValidWithToken,
-      data: {
-        ...documentRopstenValidWithToken.data,
-        issuers: [
-          {
-            ...documentRopstenValidWithToken.data.issuers[0],
-            identityProof: {
-              ...documentRopstenValidWithToken.data.issuers[0].identityProof,
-              type: null
+    it("should return a valid fragment when document has valid identity and uses document store", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              documentStore: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              identityProof: {
+                type: "1350e9f5-920b-496d-b95c-2a2793f5bff6:string:DNS-TXT",
+                location: "291a5524-f1c6-45f8-aebc-d691cf020fdd:string:example.tradetrust.io"
+              }
             }
-          }
-        ]
-      }
-    };
-    // @ts-ignore valid error, need to ignore
-    const fragment = await openAttestationDnsTxt.verify(document, {
-      network: "ropsten"
-    });
-    expect(fragment).toStrictEqual({
-      type: "ISSUER_IDENTITY",
-      name: "OpenAttestationDnsTxt",
-      data: new Error("Identity type not supported"),
-      message: "Identity type not supported",
-      status: "ERROR"
-    });
-  });
-  it("should return an error fragment when document has no identity location", async () => {
-    const document = {
-      ...documentRopstenValidWithToken,
-      data: {
-        ...documentRopstenValidWithToken.data,
-        issuers: [
-          {
-            ...documentRopstenValidWithToken.data.issuers[0],
-            identityProof: {
-              ...documentRopstenValidWithToken.data.issuers[0].identityProof,
-              location: null
+          ]
+        }
+      };
+
+      const fragment = await verify(document, {
+        network: "ropsten"
+      });
+      expect(fragment).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [
+            {
+              dns: "example.tradetrust.io",
+              status: "VALID",
+              value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
             }
-          }
-        ]
-      }
-    };
-    // @ts-ignore valid error, need to ignore
-    const fragment = await openAttestationDnsTxt.verify(document, {
-      network: "ropsten"
+          ],
+          status: "VALID"
+        }
+      ]);
     });
-    expect(fragment).toStrictEqual({
-      type: "ISSUER_IDENTITY",
-      name: "OpenAttestationDnsTxt",
-      data: new Error("Location is missing"),
-      message: "Location is missing",
-      status: "ERROR"
+    it("should return an invalid fragment when document identity does not match", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              ...documentRopstenValidWithToken.data.issuers[0],
+              tokenRegistry: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xabcd"
+            }
+          ]
+        }
+      };
+      const fragment = await verify(document, {
+        network: "ropsten"
+      });
+      expect(fragment).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [{ status: "INVALID", value: "0xabcd" }],
+          message: "Certificate issuer identity for 0xabcd is invalid",
+          status: "INVALID"
+        }
+      ]);
+    });
+    it("should return an error fragment when document has no identity location", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              ...documentRopstenValidWithToken.data.issuers[0],
+              identityProof: {
+                ...documentRopstenValidWithToken.data.issuers[0].identityProof,
+                location: null
+              }
+            }
+          ]
+        }
+      };
+      // @ts-ignore valid error, need to ignore
+      const fragment = await verify(document, {
+        network: "ropsten"
+      });
+      expect(fragment).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: new Error("Location is missing"),
+          message: "Location is missing",
+          status: "ERROR"
+        }
+      ]);
+    });
+    it("should return a skipped fragment if issuer has a tokenRegistry but does not provide identity proof", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              tokenRegistry: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              identityProof: undefined
+            }
+          ]
+        }
+      };
+      expect(
+        await verify(document, {
+          network: "ropsten"
+        })
+      ).toStrictEqual([
+        {
+          message:
+            'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+          name: "OpenAttestationDnsTxt",
+          status: "SKIPPED",
+          type: "ISSUER_IDENTITY"
+        }
+      ]);
+    });
+    it("should return a skipped fragment if issuer has a document store but does not provide identity proof", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              documentStore: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              identityProof: undefined
+            }
+          ]
+        }
+      };
+      expect(
+        await verify(document, {
+          network: "ropsten"
+        })
+      ).toStrictEqual([
+        {
+          message:
+            'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+          name: "OpenAttestationDnsTxt",
+          status: "SKIPPED",
+          type: "ISSUER_IDENTITY"
+        }
+      ]);
+    });
+    it("should return a skipped if issuer has a tokenRegistry but does not use DNS-TXT as identity proof", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              tokenRegistry: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              identityProof: {
+                type: "1350e9f5-920b-496d-b95c-2a2793f5bff6:string:OTHER-METHOD",
+                location: "291a5524-f1c6-45f8-aebc-d691cf020fdd:string:example.tradetrust.io"
+              }
+            }
+          ]
+        }
+      };
+      expect(
+        await verify(document, {
+          network: "ropsten"
+        })
+      ).toStrictEqual([
+        {
+          message:
+            'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+          name: "OpenAttestationDnsTxt",
+          status: "SKIPPED",
+          type: "ISSUER_IDENTITY"
+        }
+      ]);
+    });
+    it("should return a skipped if issuer has a documentStore but does not use DNS-TXT as identity proof", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            {
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              documentStore: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              identityProof: {
+                type: "1350e9f5-920b-496d-b95c-2a2793f5bff6:string:OTHER-METHOD",
+                location: "291a5524-f1c6-45f8-aebc-d691cf020fdd:string:example.tradetrust.io"
+              }
+            }
+          ]
+        }
+      };
+      expect(
+        await verify(document, {
+          network: "ropsten"
+        })
+      ).toStrictEqual([
+        {
+          message:
+            'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+          name: "OpenAttestationDnsTxt",
+          status: "SKIPPED",
+          type: "ISSUER_IDENTITY"
+        }
+      ]);
     });
   });
 
-  describe("test", () => {
-    it("should return true if at least one issuer has a documentStore", () => {
+  describe("with multiple issuers", () => {
+    it("should return a valid fragment when document has one issuer with document store/valid identity and a second issuer without identity", async () => {
       const document = {
         ...documentRopstenValidWithToken,
         data: {
@@ -122,23 +258,44 @@ describe("OpenAttestationDnsTxt v2 document", () => {
         }
       };
       expect(
-        openAttestationDnsTxt.test(document, {
+        await verify(document, {
           network: "ropsten"
         })
-      ).toStrictEqual(true);
+      ).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [
+            {
+              status: "SKIPPED"
+            },
+            {
+              dns: "example.tradetrust.io",
+              status: "VALID",
+              value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+            }
+          ],
+          status: "VALID"
+        }
+      ]);
     });
-    it("should return true if at least one issuer has a tokenRegistry", () => {
+    it("should return an invalid fragment when document has one issuer with document store/valid identity and a second issuer with invalid identity", async () => {
       const document = {
         ...documentRopstenValidWithToken,
         data: {
           ...documentRopstenValidWithToken.data,
           issuers: [
             {
-              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE"
+              name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
+              documentStore: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xabcd",
+              identityProof: {
+                type: "1350e9f5-920b-496d-b95c-2a2793f5bff6:string:DNS-TXT",
+                location: "291a5524-f1c6-45f8-aebc-d691cf020fdd:string:example.tradetrust.io"
+              }
             },
             {
               name: "2433e228-5bee-4863-9b98-2337f4f90306:string:DEMO STORE",
-              tokenRegistry: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+              documentStore: "1d337929-6770-4a05-ace0-1f07c25c7615:string:0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
               identityProof: {
                 type: "1350e9f5-920b-496d-b95c-2a2793f5bff6:string:DNS-TXT",
                 location: "291a5524-f1c6-45f8-aebc-d691cf020fdd:string:example.tradetrust.io"
@@ -148,12 +305,66 @@ describe("OpenAttestationDnsTxt v2 document", () => {
         }
       };
       expect(
-        openAttestationDnsTxt.test(document, {
+        await verify(document, {
           network: "ropsten"
         })
-      ).toStrictEqual(true);
+      ).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [
+            {
+              status: "INVALID",
+              value: "0xabcd"
+            },
+            {
+              dns: "example.tradetrust.io",
+              status: "VALID",
+              value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+            }
+          ],
+          message: "Certificate issuer identity for 0xabcd is invalid",
+          status: "INVALID"
+        }
+      ]);
     });
-    it("should return false if no issuer has a tokenRegistry or documentStore", () => {
+    it("should return a valid fragment when document has one issuer with token registry/valid identity and a second issuer without identity", async () => {
+      const document = {
+        ...documentRopstenValidWithToken,
+        data: {
+          ...documentRopstenValidWithToken.data,
+          issuers: [
+            documentRopstenValidWithToken.data.issuers[0],
+            {
+              ...documentRopstenValidWithToken.data.issuers[0],
+              identityProof: undefined
+            }
+          ]
+        }
+      };
+
+      const fragment = await verify(document, {
+        network: "ropsten"
+      });
+      expect(fragment).toStrictEqual([
+        {
+          type: "ISSUER_IDENTITY",
+          name: "OpenAttestationDnsTxt",
+          data: [
+            {
+              dns: "example.tradetrust.io",
+              status: "VALID",
+              value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+            },
+            {
+              status: "SKIPPED"
+            }
+          ],
+          status: "VALID"
+        }
+      ]);
+    });
+    it("should return skipped fragment if no issuer has a tokenRegistry or documentStore", async () => {
       const document = {
         ...documentRopstenValidWithToken,
         data: {
@@ -170,10 +381,18 @@ describe("OpenAttestationDnsTxt v2 document", () => {
         }
       };
       expect(
-        openAttestationDnsTxt.test(document, {
+        await verify(document, {
           network: "ropsten"
         })
-      ).toStrictEqual(false);
+      ).toStrictEqual([
+        {
+          message:
+            'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+          name: "OpenAttestationDnsTxt",
+          status: "SKIPPED",
+          type: "ISSUER_IDENTITY"
+        }
+      ]);
     });
   });
 });

--- a/src/verifiers/openAttestationDnsTxt.v3.test.ts
+++ b/src/verifiers/openAttestationDnsTxt.v3.test.ts
@@ -26,8 +26,8 @@ describe("OpenAttestationDnsTxt v3 document", () => {
       name: "OpenAttestationDnsTxt",
       data: {
         dns: "example.openattestation.com",
-        identified: true,
-        smartContract: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3"
+        status: "VALID",
+        value: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3"
       },
       status: "VALID"
     });

--- a/src/verify.v2.integration.test.ts
+++ b/src/verify.v2.integration.test.ts
@@ -231,8 +231,8 @@ describe("verify(integration)", () => {
         data: [
           {
             dns: "example.tradetrust.io",
-            identified: true,
-            smartContract: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
+            status: "VALID",
+            value: "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe"
           }
         ],
         status: "VALID",
@@ -290,8 +290,8 @@ describe("verify(integration)", () => {
         data: [
           {
             dns: "tradetrust.io",
-            identified: true,
-            smartContract: "0x48399Fb88bcD031C556F53e93F690EEC07963Af3"
+            status: "VALID",
+            value: "0x48399Fb88bcD031C556F53e93F690EEC07963Af3"
           }
         ],
         status: "VALID",


### PR DESCRIPTION
- only verify if the issuer is using DNS-TXT (dont throw error if he's not)
- added resolution status for every issuer, even if it has been skipped for one person
- forward the resolution status in the data object