### PR TITLE
Chore/did signed adam comment

### DIFF
--- a/src/verifiers/documentStatus/didSignedDocumentStatus/didSignedDocumentStatus.test.ts
+++ b/src/verifiers/documentStatus/didSignedDocumentStatus/didSignedDocumentStatus.test.ts
@@ -24,6 +24,13 @@ const whenPublicKeyResolvesSuccessfully = () => {
   });
 };
 
+import { Wallet, utils } from "ethers";
+it("signs", () => {
+  const wallet = new Wallet("0x497c85ed89f1874ba37532d1e33519aba15bd533cdcb90774cc497bfe3cde655");
+  const merkleRoot = "0xd0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5";
+  console.log(wallet.signMessage(utils.arrayify(merkleRoot)));
+});
+
 // TODO Temporarily passing in this option, until make the entire option optional in another PR
 const options = {
   network: "ropsten",

--- a/src/verifiers/documentStatus/didSignedDocumentStatus/didSignedDocumentStatus.test.ts
+++ b/src/verifiers/documentStatus/didSignedDocumentStatus/didSignedDocumentStatus.test.ts
@@ -24,13 +24,6 @@ const whenPublicKeyResolvesSuccessfully = () => {
   });
 };
 
-import { Wallet, utils } from "ethers";
-it("signs", () => {
-  const wallet = new Wallet("0x497c85ed89f1874ba37532d1e33519aba15bd533cdcb90774cc497bfe3cde655");
-  const merkleRoot = "0xd0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5";
-  console.log(wallet.signMessage(utils.arrayify(merkleRoot)));
-});
-
 // TODO Temporarily passing in this option, until make the entire option optional in another PR
 const options = {
   network: "ropsten",

--- a/test/fixtures/v2/documentDidCustomRevocation.ts
+++ b/test/fixtures/v2/documentDidCustomRevocation.ts
@@ -1,64 +1,58 @@
 export const documentDidCustomRevocation: any = {
   version: "https://schema.openattestation.com/2.0/schema.json",
   data: {
-    id: "3b015577-0f88-4568-9b71-b9e3bc3a9d22:string:SGCNM21566325",
+    id: "875d57ec-2768-408a-b8d3-bb5ebda17b80:string:SGCNM21566325",
     $template: {
-      name: "23db7ca9-825c-4178-b951-f53a1c1ba8f9:string:CERTIFICATE_OF_NON_MANIPULATION",
-      type: "f31b4c6e-f68a-4de9-bd94-1a84e2a2bbbf:string:EMBEDDED_RENDERER",
-      url: "2746d44a-a5da-4fb3-a334-c4e2b7ebd181:string:https://demo-cnm.openattestation.com",
+      name: "1449b124-9bc4-4722-bed1-47272c69f802:string:CERTIFICATE_OF_NON_MANIPULATION",
+      type: "ba303026-4130-4801-a6a0-1d17db61a6c5:string:EMBEDDED_RENDERER",
+      url: "87c3c915-4d6e-4f27-b7d1-614181d2f620:string:https://demo-cnm.openattestation.com",
     },
     issuers: [
       {
-        name: "dd05a2ed-04c8-4713-b108-72bb7ea4e47a:string:DEMO STORE",
+        id: "21d8b192-f449-4413-a311-5c9e211082d6:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        name: "f1ca0af7-5e9a-45f3-8635-720babd76387:string:DEMO STORE",
         revocation: {
-          type: "a1829139-a274-409e-a21e-7d08666d2952:string:CUSTOM",
-          foo: "5f626461-63f0-453f-a875-b9c8b03fe920:string:BAR",
+          type: "edcb13e4-1e1a-4317-a194-ec372345c14f:string:CUSTOM",
+          foo: "4f18c9c0-e872-44b0-961e-23c3e6b7be50:string:bar",
         },
         identityProof: {
-          type: "c1230275-89b3-4c44-b755-626b854a89e5:string:DID",
-          id: "86eac6e9-7442-4099-a01e-6304eb03cdaa:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          purpose: "4f6704ef-278b-4751-b6c1-07e2dcf31eda:string:DOCUMENT_ISSUANCE",
-          key: {
-            id:
-              "38de287f-5d23-4789-8df8-c60043ab202f:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
-            type: "dd9e4541-36c1-4e59-8087-7f2e05413461:string:Secp256k1VerificationKey2018",
-            ethereumAddress: "5bbc7f70-e0bb-4f32-a7d5-b0c5df82f5a5:string:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-            owner: "68c4ed9f-2a72-4b31-a29c-777494e7e8e8:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          },
+          type: "877d7405-ee94-434a-a258-ec6add2877d5:string:DID",
+          key:
+            "37fec355-da53-4c2f-b8d7-b064b305e879:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
         },
       },
     ],
     recipient: {
-      name: "b6e85c9f-cbbc-4aa9-ac43-0b17b1133283:string:SG FREIGHT",
+      name: "8a5bffe7-ceb1-41b9-b240-84025eebdc0c:string:SG FREIGHT",
       address: {
-        street: "becaa52d-2d57-4984-8df3-6f83fdf7d4cc:string:101 ORCHARD ROAD",
-        country: "cc6cf75e-3d6b-4c1a-a619-5d9f4b898684:string:SINGAPORE",
+        street: "83265d64-7fc8-4201-b21e-0b87d5bc8007:string:101 ORCHARD ROAD",
+        country: "beb02ccd-02cf-48c2-adb2-9ea1b55442b0:string:SINGAPORE",
       },
     },
     consignment: {
-      description: "662aad56-c334-475c-9e81-140130de4863:string:16667 CARTONS OF RED WINE",
+      description: "bfd4a9ae-47fb-4b72-a131-1827d45f8b72:string:16667 CARTONS OF RED WINE",
       quantity: {
-        value: "513997aa-fad1-4a3f-82d1-9b77643267d7:number:5000",
-        unit: "79e25740-22a2-4111-8c9b-1f348b8d5035:string:LITRES",
+        value: "003d32f5-e663-48f1-ac7d-db4ae1f79cce:number:5000",
+        unit: "2dac8afd-3a2b-43f5-9853-b92ad5727fd2:string:LITRES",
       },
-      countryOfOrigin: "879e30bf-3de3-4c82-b7ea-0f7593ae195d:string:AUSTRALIA",
-      outwardBillNo: "3a303587-ed64-494b-87dd-27995bf0f5c9:string:AQSIQ170923130",
-      dateOfDischarge: "9e937f2f-fc94-4f64-944b-6fd3d151d312:string:2018-01-26",
-      dateOfDeparture: "29af5d36-bba2-48cd-b87f-3c889093bff6:string:2018-01-30",
-      countryOfFinalDestination: "a523c2ab-8dcd-4598-8da2-8112a8b2addc:string:CHINA",
-      outgoingVehicleNo: "dea8373e-114a-4a9d-a5ec-119accd7b027:string:COSCO JAPAN 074E/30-JAN",
+      countryOfOrigin: "20e4cadc-41e8-49b0-bad9-534f4cdae00f:string:AUSTRALIA",
+      outwardBillNo: "3cb5790f-379d-4360-884b-d45345437394:string:AQSIQ170923130",
+      dateOfDischarge: "1d774eb3-759d-4d3e-a38f-1aaa5579a3fe:string:2018-01-26",
+      dateOfDeparture: "0538a21c-acdd-4de3-aa33-9000b818dc9a:string:2018-01-30",
+      countryOfFinalDestination: "2a55a98e-0043-4f26-b23b-7b08d2c30505:string:CHINA",
+      outgoingVehicleNo: "154ae7f3-74dc-4972-b001-275a929cb72a:string:COSCO JAPAN 074E/30-JAN",
     },
     declaration: {
-      name: "45e4fad8-7671-46ce-ad8c-a7cb1a4ce5fe:string:PETER LEE",
-      designation: "9bd77cf3-2240-473d-9c5b-9cbfdb2581e6:string:SHIPPING MANAGER",
-      date: "94eb16ce-47ef-4b70-a139-bf268f676db8:string:2018-01-28",
+      name: "397bd565-7902-4201-92fd-2a7b3686d740:string:PETER LEE",
+      designation: "53feef96-c973-4f03-bdee-3bae76b139e3:string:SHIPPING MANAGER",
+      date: "52c7a56b-23ab-41b5-b7f6-a86e9fbeae44:string:2018-01-28",
     },
   },
   signature: {
     type: "SHA3MerkleProof",
-    targetHash: "b51cb42afd96ddfb6698b32224ef9b79e57914c718ada76a85d4d1f8292828d3",
+    targetHash: "eea9ad6c2998a3d00fe70f91b3c6cefcd7a5c2068e6b13c9d93c00e5d4fcec1a",
     proof: [],
-    merkleRoot: "b51cb42afd96ddfb6698b32224ef9b79e57914c718ada76a85d4d1f8292828d3",
+    merkleRoot: "eea9ad6c2998a3d00fe70f91b3c6cefcd7a5c2068e6b13c9d93c00e5d4fcec1a",
   },
   proof: [
     {
@@ -66,7 +60,7 @@ export const documentDidCustomRevocation: any = {
       proofPurpose: "assertionMethod",
       verificationMethod: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
       signature:
-        "0x1b9a0c17f613685ab9b82bca4c6e13c380bdee50ed127f690201bf8dba906e2c7c8bf74a6baedd76ea362893864437056a5ad7ef6678e74b2afcdcf6560199581c",
+        "0x5fff5ed3d62fbe92b7a358260f924ea31ba57c53d01fe849d4fc3843beec4b7345a1c00035cf96f11cab9d908ad10aac8d077d5feca2c393240c9cc9e0b9c7e81b",
     },
   ],
 };

--- a/test/fixtures/v2/documentDidMissingProof.ts
+++ b/test/fixtures/v2/documentDidMissingProof.ts
@@ -1,60 +1,54 @@
 export const documentDidMissingProof: any = {
   version: "https://schema.openattestation.com/2.0/schema.json",
   data: {
-    id: "c4deaa44-b58a-4c9f-b66b-30c0c28f81c9:string:SGCNM21566325",
+    id: "e1917cfe-70fa-4187-ac6d-ccc57c0d4645:string:SGCNM21566325",
     $template: {
-      name: "0b0220dc-e16e-4ef4-8a4c-7ffd021d9c58:string:CERTIFICATE_OF_NON_MANIPULATION",
-      type: "7247b6c5-0bed-4393-ac85-a97482ae208a:string:EMBEDDED_RENDERER",
-      url: "1b8fe35e-c338-4061-bb22-17a791ad06b8:string:https://demo-cnm.openattestation.com",
+      name: "95b39779-f300-43b7-9010-1eb96eafc6b5:string:CERTIFICATE_OF_NON_MANIPULATION",
+      type: "43e9f19d-1ebd-485d-8cbf-2726c1f7c755:string:EMBEDDED_RENDERER",
+      url: "7b0602b0-5e55-42de-813a-27c4f2b54d20:string:https://demo-cnm.openattestation.com",
     },
     issuers: [
       {
-        name: "48c17918-af33-4578-a0ce-0efbcad6a088:string:DEMO STORE",
-        revocation: { type: "15c54c38-d2eb-4c5d-adf9-41f028be1f89:string:NONE" },
+        id: "6002d4ab-d1a6-447e-9f86-945ee220fedb:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        name: "f46a0b69-983b-4b5e-83f6-aebe14625810:string:DEMO STORE",
+        revocation: { type: "bcd9fe64-1b8a-41d3-a176-5d750b4a6cef:string:NONE" },
         identityProof: {
-          type: "4d9787d9-05f5-48fe-9e4f-8d8577c1612d:string:DID",
-          id: "859aae23-cf04-45bb-b687-43e4d20b0790:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          purpose: "7f2b206e-1113-430f-b059-19cc9c8b5694:string:DOCUMENT_ISSUANCE",
-          key: {
-            id:
-              "bdfdb9d3-eb25-437e-8d9b-36fef84430c1:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
-            type: "aad3b14c-930c-45ee-8d00-94cd28696028:string:Secp256k1VerificationKey2018",
-            ethereumAddress: "e33ec706-af23-4a20-9395-3a5ca273f725:string:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-            owner: "1b55da7c-cb73-44a1-9499-4aac5c6478a2:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          },
+          type: "c2990f33-814c-4c7f-a14c-8cef4b1aa8ad:string:DID",
+          key:
+            "4ef2653f-7fb5-409b-acc1-a76344ff2de0:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
         },
       },
     ],
     recipient: {
-      name: "c94682ae-3c60-4d78-ba5c-32133a0ac8e3:string:SG FREIGHT",
+      name: "a5bcf044-94e4-421e-a0d6-960546dc3b41:string:SG FREIGHT",
       address: {
-        street: "eb2563d0-642e-4ab1-9756-75c5fe219a70:string:101 ORCHARD ROAD",
-        country: "6b13f61c-ffa0-44f9-b84b-7cf71f202cc4:string:SINGAPORE",
+        street: "1b8dc011-05e0-405e-a687-4b2292a9455a:string:101 ORCHARD ROAD",
+        country: "39f0508c-637c-407f-9087-c0d1239c9407:string:SINGAPORE",
       },
     },
     consignment: {
-      description: "cd7c8fa1-42e0-41b5-97c1-08540a7b4770:string:16667 CARTONS OF RED WINE",
+      description: "6819ad4b-ffb2-427c-ac5a-6b812cbefff9:string:16667 CARTONS OF RED WINE",
       quantity: {
-        value: "8479ec0a-c8d0-4c86-8117-a25a31c0670d:number:5000",
-        unit: "57fdf963-fc94-4a9c-99e8-5f9ec076b754:string:LITRES",
+        value: "fb57e16f-d2f4-4caa-8c37-86514695a3ac:number:5000",
+        unit: "b4259694-628d-4dc0-bce1-f7d34bab8a75:string:LITRES",
       },
-      countryOfOrigin: "50f56128-3f61-4318-b2e2-37124b9273dd:string:AUSTRALIA",
-      outwardBillNo: "050fd84b-7229-4ab8-9b20-8ffc5786f7fd:string:AQSIQ170923130",
-      dateOfDischarge: "a50ca7fe-0b99-4bd4-b72c-f38fbc79c520:string:2018-01-26",
-      dateOfDeparture: "2895e14b-9de6-4d03-88b1-0b5d2f5ed3ef:string:2018-01-30",
-      countryOfFinalDestination: "e9f9a317-db5f-4eed-a50e-9d861cdc91c6:string:CHINA",
-      outgoingVehicleNo: "4cbbb08a-3c33-4662-920c-d5ec669157c2:string:COSCO JAPAN 074E/30-JAN",
+      countryOfOrigin: "68c4b3bf-6ecf-4b55-894b-3def8c287c6f:string:AUSTRALIA",
+      outwardBillNo: "2f5b4abf-47d8-4530-8e13-0f78688637e5:string:AQSIQ170923130",
+      dateOfDischarge: "5dde46da-25cb-4721-96c8-a8f7fee4789a:string:2018-01-26",
+      dateOfDeparture: "6cc4d4bd-52a4-4998-9cf7-c32a86e78fb0:string:2018-01-30",
+      countryOfFinalDestination: "054ea1a5-37ae-4625-b8bf-d2ac43ddfcf2:string:CHINA",
+      outgoingVehicleNo: "11ac7f5b-2839-4d27-b4fb-7ac77acb36c7:string:COSCO JAPAN 074E/30-JAN",
     },
     declaration: {
-      name: "46ddec62-8f62-485b-aca3-98693ae78420:string:PETER LEE",
-      designation: "31a90254-0f93-4273-919d-2e61b7ad0493:string:SHIPPING MANAGER",
-      date: "5fed8d09-4a7d-4041-8e30-0f3466def614:string:2018-01-28",
+      name: "1954f051-1fde-4288-8468-5020dcc883a6:string:PETER LEE",
+      designation: "07ff6d5c-40e5-496d-86fd-704866dc8e06:string:SHIPPING MANAGER",
+      date: "3873ff50-223f-41d0-b37c-6572328594ae:string:2018-01-28",
     },
   },
   signature: {
     type: "SHA3MerkleProof",
-    targetHash: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    targetHash: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
     proof: [],
-    merkleRoot: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    merkleRoot: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
   },
 };

--- a/test/fixtures/v2/documentDidObfuscatedRevocation.ts
+++ b/test/fixtures/v2/documentDidObfuscatedRevocation.ts
@@ -1,60 +1,57 @@
 export const documentDidObfuscatedRevocation: any = {
   version: "https://schema.openattestation.com/2.0/schema.json",
   data: {
-    id: "c4deaa44-b58a-4c9f-b66b-30c0c28f81c9:string:SGCNM21566325",
+    id: "e1917cfe-70fa-4187-ac6d-ccc57c0d4645:string:SGCNM21566325",
     $template: {
-      name: "0b0220dc-e16e-4ef4-8a4c-7ffd021d9c58:string:CERTIFICATE_OF_NON_MANIPULATION",
-      type: "7247b6c5-0bed-4393-ac85-a97482ae208a:string:EMBEDDED_RENDERER",
-      url: "1b8fe35e-c338-4061-bb22-17a791ad06b8:string:https://demo-cnm.openattestation.com",
+      name: "95b39779-f300-43b7-9010-1eb96eafc6b5:string:CERTIFICATE_OF_NON_MANIPULATION",
+      type: "43e9f19d-1ebd-485d-8cbf-2726c1f7c755:string:EMBEDDED_RENDERER",
+      url: "7b0602b0-5e55-42de-813a-27c4f2b54d20:string:https://demo-cnm.openattestation.com",
     },
     issuers: [
       {
-        name: "48c17918-af33-4578-a0ce-0efbcad6a088:string:DEMO STORE",
+        id: "6002d4ab-d1a6-447e-9f86-945ee220fedb:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        name: "f46a0b69-983b-4b5e-83f6-aebe14625810:string:DEMO STORE",
         identityProof: {
-          type: "4d9787d9-05f5-48fe-9e4f-8d8577c1612d:string:DID",
-          id: "859aae23-cf04-45bb-b687-43e4d20b0790:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          purpose: "7f2b206e-1113-430f-b059-19cc9c8b5694:string:DOCUMENT_ISSUANCE",
-          key: {
-            id:
-              "bdfdb9d3-eb25-437e-8d9b-36fef84430c1:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
-            type: "aad3b14c-930c-45ee-8d00-94cd28696028:string:Secp256k1VerificationKey2018",
-            ethereumAddress: "e33ec706-af23-4a20-9395-3a5ca273f725:string:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-            owner: "1b55da7c-cb73-44a1-9499-4aac5c6478a2:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          },
+          type: "c2990f33-814c-4c7f-a14c-8cef4b1aa8ad:string:DID",
+          key:
+            "4ef2653f-7fb5-409b-acc1-a76344ff2de0:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
         },
       },
     ],
     recipient: {
-      name: "c94682ae-3c60-4d78-ba5c-32133a0ac8e3:string:SG FREIGHT",
+      name: "a5bcf044-94e4-421e-a0d6-960546dc3b41:string:SG FREIGHT",
       address: {
-        street: "eb2563d0-642e-4ab1-9756-75c5fe219a70:string:101 ORCHARD ROAD",
-        country: "6b13f61c-ffa0-44f9-b84b-7cf71f202cc4:string:SINGAPORE",
+        street: "1b8dc011-05e0-405e-a687-4b2292a9455a:string:101 ORCHARD ROAD",
+        country: "39f0508c-637c-407f-9087-c0d1239c9407:string:SINGAPORE",
       },
     },
     consignment: {
-      description: "cd7c8fa1-42e0-41b5-97c1-08540a7b4770:string:16667 CARTONS OF RED WINE",
+      description: "6819ad4b-ffb2-427c-ac5a-6b812cbefff9:string:16667 CARTONS OF RED WINE",
       quantity: {
-        value: "8479ec0a-c8d0-4c86-8117-a25a31c0670d:number:5000",
-        unit: "57fdf963-fc94-4a9c-99e8-5f9ec076b754:string:LITRES",
+        value: "fb57e16f-d2f4-4caa-8c37-86514695a3ac:number:5000",
+        unit: "b4259694-628d-4dc0-bce1-f7d34bab8a75:string:LITRES",
       },
-      countryOfOrigin: "50f56128-3f61-4318-b2e2-37124b9273dd:string:AUSTRALIA",
-      outwardBillNo: "050fd84b-7229-4ab8-9b20-8ffc5786f7fd:string:AQSIQ170923130",
-      dateOfDischarge: "a50ca7fe-0b99-4bd4-b72c-f38fbc79c520:string:2018-01-26",
-      dateOfDeparture: "2895e14b-9de6-4d03-88b1-0b5d2f5ed3ef:string:2018-01-30",
-      countryOfFinalDestination: "e9f9a317-db5f-4eed-a50e-9d861cdc91c6:string:CHINA",
-      outgoingVehicleNo: "4cbbb08a-3c33-4662-920c-d5ec669157c2:string:COSCO JAPAN 074E/30-JAN",
+      countryOfOrigin: "68c4b3bf-6ecf-4b55-894b-3def8c287c6f:string:AUSTRALIA",
+      outwardBillNo: "2f5b4abf-47d8-4530-8e13-0f78688637e5:string:AQSIQ170923130",
+      dateOfDischarge: "5dde46da-25cb-4721-96c8-a8f7fee4789a:string:2018-01-26",
+      dateOfDeparture: "6cc4d4bd-52a4-4998-9cf7-c32a86e78fb0:string:2018-01-30",
+      countryOfFinalDestination: "054ea1a5-37ae-4625-b8bf-d2ac43ddfcf2:string:CHINA",
+      outgoingVehicleNo: "11ac7f5b-2839-4d27-b4fb-7ac77acb36c7:string:COSCO JAPAN 074E/30-JAN",
     },
     declaration: {
-      name: "46ddec62-8f62-485b-aca3-98693ae78420:string:PETER LEE",
-      designation: "31a90254-0f93-4273-919d-2e61b7ad0493:string:SHIPPING MANAGER",
-      date: "5fed8d09-4a7d-4041-8e30-0f3466def614:string:2018-01-28",
+      name: "1954f051-1fde-4288-8468-5020dcc883a6:string:PETER LEE",
+      designation: "07ff6d5c-40e5-496d-86fd-704866dc8e06:string:SHIPPING MANAGER",
+      date: "3873ff50-223f-41d0-b37c-6572328594ae:string:2018-01-28",
     },
   },
   signature: {
     type: "SHA3MerkleProof",
-    targetHash: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    targetHash: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
     proof: [],
-    merkleRoot: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    merkleRoot: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
+  },
+  privacy: {
+    obfuscatedData: ["3dcde1cfa4a6716392514fd5ea8c451c82081a5f2d95f0fc7b045c4f461389ee"],
   },
   proof: [
     {
@@ -62,10 +59,7 @@ export const documentDidObfuscatedRevocation: any = {
       proofPurpose: "assertionMethod",
       verificationMethod: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
       signature:
-        "0x0974ce1ed68a24f90f4b8d1a797f59674e13bad9f9caa2e59ae5206101d8dad16b464c83c1cbf65c40e2a99fdd2f34b2c570c36c8b648713b51b8903416b2acc1b",
+        "0xff0227ce8400a17a2d80073a95fd895f4fed0011954c90eef389bc618087a4b36ed958775420d122e9a6764c6ffe9d3302d4f45fb065d5e962c3572d3872f31a1b",
     },
   ],
-  privacy: {
-    obfuscatedData: ["fc3cb56fe0c9a5ac1a91af35b1d3a61c976a0158a35dc0709550c97b21a8b2ae"],
-  },
 };

--- a/test/fixtures/v2/documentDidSigned.ts
+++ b/test/fixtures/v2/documentDidSigned.ts
@@ -1,61 +1,55 @@
 export const documentDidSigned: any = {
   version: "https://schema.openattestation.com/2.0/schema.json",
   data: {
-    id: "c4deaa44-b58a-4c9f-b66b-30c0c28f81c9:string:SGCNM21566325",
+    id: "e1917cfe-70fa-4187-ac6d-ccc57c0d4645:string:SGCNM21566325",
     $template: {
-      name: "0b0220dc-e16e-4ef4-8a4c-7ffd021d9c58:string:CERTIFICATE_OF_NON_MANIPULATION",
-      type: "7247b6c5-0bed-4393-ac85-a97482ae208a:string:EMBEDDED_RENDERER",
-      url: "1b8fe35e-c338-4061-bb22-17a791ad06b8:string:https://demo-cnm.openattestation.com",
+      name: "95b39779-f300-43b7-9010-1eb96eafc6b5:string:CERTIFICATE_OF_NON_MANIPULATION",
+      type: "43e9f19d-1ebd-485d-8cbf-2726c1f7c755:string:EMBEDDED_RENDERER",
+      url: "7b0602b0-5e55-42de-813a-27c4f2b54d20:string:https://demo-cnm.openattestation.com",
     },
     issuers: [
       {
-        name: "48c17918-af33-4578-a0ce-0efbcad6a088:string:DEMO STORE",
-        revocation: { type: "15c54c38-d2eb-4c5d-adf9-41f028be1f89:string:NONE" },
+        id: "6002d4ab-d1a6-447e-9f86-945ee220fedb:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        name: "f46a0b69-983b-4b5e-83f6-aebe14625810:string:DEMO STORE",
+        revocation: { type: "bcd9fe64-1b8a-41d3-a176-5d750b4a6cef:string:NONE" },
         identityProof: {
-          type: "4d9787d9-05f5-48fe-9e4f-8d8577c1612d:string:DID",
-          id: "859aae23-cf04-45bb-b687-43e4d20b0790:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          purpose: "7f2b206e-1113-430f-b059-19cc9c8b5694:string:DOCUMENT_ISSUANCE",
-          key: {
-            id:
-              "bdfdb9d3-eb25-437e-8d9b-36fef84430c1:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
-            type: "aad3b14c-930c-45ee-8d00-94cd28696028:string:Secp256k1VerificationKey2018",
-            ethereumAddress: "e33ec706-af23-4a20-9395-3a5ca273f725:string:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-            owner: "1b55da7c-cb73-44a1-9499-4aac5c6478a2:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          },
+          type: "c2990f33-814c-4c7f-a14c-8cef4b1aa8ad:string:DID",
+          key:
+            "4ef2653f-7fb5-409b-acc1-a76344ff2de0:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
         },
       },
     ],
     recipient: {
-      name: "c94682ae-3c60-4d78-ba5c-32133a0ac8e3:string:SG FREIGHT",
+      name: "a5bcf044-94e4-421e-a0d6-960546dc3b41:string:SG FREIGHT",
       address: {
-        street: "eb2563d0-642e-4ab1-9756-75c5fe219a70:string:101 ORCHARD ROAD",
-        country: "6b13f61c-ffa0-44f9-b84b-7cf71f202cc4:string:SINGAPORE",
+        street: "1b8dc011-05e0-405e-a687-4b2292a9455a:string:101 ORCHARD ROAD",
+        country: "39f0508c-637c-407f-9087-c0d1239c9407:string:SINGAPORE",
       },
     },
     consignment: {
-      description: "cd7c8fa1-42e0-41b5-97c1-08540a7b4770:string:16667 CARTONS OF RED WINE",
+      description: "6819ad4b-ffb2-427c-ac5a-6b812cbefff9:string:16667 CARTONS OF RED WINE",
       quantity: {
-        value: "8479ec0a-c8d0-4c86-8117-a25a31c0670d:number:5000",
-        unit: "57fdf963-fc94-4a9c-99e8-5f9ec076b754:string:LITRES",
+        value: "fb57e16f-d2f4-4caa-8c37-86514695a3ac:number:5000",
+        unit: "b4259694-628d-4dc0-bce1-f7d34bab8a75:string:LITRES",
       },
-      countryOfOrigin: "50f56128-3f61-4318-b2e2-37124b9273dd:string:AUSTRALIA",
-      outwardBillNo: "050fd84b-7229-4ab8-9b20-8ffc5786f7fd:string:AQSIQ170923130",
-      dateOfDischarge: "a50ca7fe-0b99-4bd4-b72c-f38fbc79c520:string:2018-01-26",
-      dateOfDeparture: "2895e14b-9de6-4d03-88b1-0b5d2f5ed3ef:string:2018-01-30",
-      countryOfFinalDestination: "e9f9a317-db5f-4eed-a50e-9d861cdc91c6:string:CHINA",
-      outgoingVehicleNo: "4cbbb08a-3c33-4662-920c-d5ec669157c2:string:COSCO JAPAN 074E/30-JAN",
+      countryOfOrigin: "68c4b3bf-6ecf-4b55-894b-3def8c287c6f:string:AUSTRALIA",
+      outwardBillNo: "2f5b4abf-47d8-4530-8e13-0f78688637e5:string:AQSIQ170923130",
+      dateOfDischarge: "5dde46da-25cb-4721-96c8-a8f7fee4789a:string:2018-01-26",
+      dateOfDeparture: "6cc4d4bd-52a4-4998-9cf7-c32a86e78fb0:string:2018-01-30",
+      countryOfFinalDestination: "054ea1a5-37ae-4625-b8bf-d2ac43ddfcf2:string:CHINA",
+      outgoingVehicleNo: "11ac7f5b-2839-4d27-b4fb-7ac77acb36c7:string:COSCO JAPAN 074E/30-JAN",
     },
     declaration: {
-      name: "46ddec62-8f62-485b-aca3-98693ae78420:string:PETER LEE",
-      designation: "31a90254-0f93-4273-919d-2e61b7ad0493:string:SHIPPING MANAGER",
-      date: "5fed8d09-4a7d-4041-8e30-0f3466def614:string:2018-01-28",
+      name: "1954f051-1fde-4288-8468-5020dcc883a6:string:PETER LEE",
+      designation: "07ff6d5c-40e5-496d-86fd-704866dc8e06:string:SHIPPING MANAGER",
+      date: "3873ff50-223f-41d0-b37c-6572328594ae:string:2018-01-28",
     },
   },
   signature: {
     type: "SHA3MerkleProof",
-    targetHash: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    targetHash: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
     proof: [],
-    merkleRoot: "2a77f5aea82add5574eaa4f4bde9a6c9e0230fb6e99489edfd5e51dce81be055",
+    merkleRoot: "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
   },
   proof: [
     {
@@ -63,7 +57,7 @@ export const documentDidSigned: any = {
       proofPurpose: "assertionMethod",
       verificationMethod: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
       signature:
-        "0x0974ce1ed68a24f90f4b8d1a797f59674e13bad9f9caa2e59ae5206101d8dad16b464c83c1cbf65c40e2a99fdd2f34b2c570c36c8b648713b51b8903416b2acc1b",
+        "0xff0227ce8400a17a2d80073a95fd895f4fed0011954c90eef389bc618087a4b36ed958775420d122e9a6764c6ffe9d3302d4f45fb065d5e962c3572d3872f31a1b",
     },
   ],
 };

--- a/test/fixtures/v2/documentDnsDidSigned.ts
+++ b/test/fixtures/v2/documentDnsDidSigned.ts
@@ -1,62 +1,56 @@
 export const documentDnsDidSigned: any = {
   version: "https://schema.openattestation.com/2.0/schema.json",
   data: {
-    id: "cfd355d4-6cbb-48eb-ac57-4feb49cc8ee7:string:SGCNM21566325",
+    id: "9a472a0a-42db-4559-baf2-90d6fcc2b113:string:SGCNM21566325",
     $template: {
-      name: "778cc6a0-153a-4562-96b6-3528bef74f51:string:CERTIFICATE_OF_NON_MANIPULATION",
-      type: "7adc647c-2222-46e1-9e48-21d7648e3469:string:EMBEDDED_RENDERER",
-      url: "65a266a6-f946-4f16-9791-3761680963a9:string:https://demo-cnm.openattestation.com",
+      name: "e2da3963-d070-43e0-9cce-888886cd3173:string:CERTIFICATE_OF_NON_MANIPULATION",
+      type: "f6b1b012-7dcb-4725-952d-228708746a21:string:EMBEDDED_RENDERER",
+      url: "f64728c6-b985-465c-a31c-d2c98d5e055a:string:https://demo-cnm.openattestation.com",
     },
     issuers: [
       {
-        name: "2ad7b7bf-6393-4652-8f8c-abffb0bf67d6:string:DEMO STORE",
-        revocation: { type: "aedab589-b5f3-4fc1-a319-622f2598f4c5:string:NONE" },
+        id: "27f71dea-839c-4484-8a72-72f974a3c093:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        name: "cc8465bc-4432-47cf-94bf-0ee0c8c49c22:string:DEMO STORE",
+        revocation: { type: "85debc04-1698-4a1b-b6ac-7ef7e8f9d4b4:string:NONE" },
         identityProof: {
-          type: "92e015c0-4088-4a98-ab71-773f2a168812:string:DNS-DID",
-          id: "93b65e69-3f22-457c-bc70-94fe8cb6dbe4:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          purpose: "00155b5c-bf3d-4fc4-b797-213a65b7c874:string:DOCUMENT_ISSUANCE",
-          key: {
-            id:
-              "77ef8de2-3eb1-42c0-a704-3b14b7d72e27:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
-            type: "ed3d6420-00d2-4d85-b851-dfdbf153530b:string:Secp256k1VerificationKey2018",
-            ethereumAddress: "8bfc8b01-d42f-4e73-99c9-08be7dc58118:string:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-            owner: "cbf141ba-c73c-4d11-b61f-96b09b1a54c4:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
-          },
-          location: "5e7cf7d2-e52e-4b01-927b-3de070d619bd:string:example.tradetrust.io",
+          type: "767bd2d0-f1e4-4471-81a0-c4056d42f592:string:DNS-DID",
+          key:
+            "5edf0191-5492-4659-891b-84e68793c9be:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+          location: "ad412e6a-a9b6-40e6-bb17-18b097d86833:string:example.tradetrust.io",
         },
       },
     ],
     recipient: {
-      name: "53c65319-2437-46cd-8ef5-dd7777b8e8e4:string:SG FREIGHT",
+      name: "243cdac1-8d75-47ca-a4f3-b9e305f16f50:string:SG FREIGHT",
       address: {
-        street: "1bc8ae6e-2d19-4ceb-bd7a-adbf2f848e5a:string:101 ORCHARD ROAD",
-        country: "6179b694-90b0-4ce0-8961-16f43f58b3ac:string:SINGAPORE",
+        street: "241f4d4f-ddeb-4344-a0e5-6a766b664c38:string:101 ORCHARD ROAD",
+        country: "b66e2078-1bb2-41e3-b60b-0a16b6b79639:string:SINGAPORE",
       },
     },
     consignment: {
-      description: "0e3537ec-cdee-4ef2-8d9c-22d8bcfa543c:string:16667 CARTONS OF RED WINE",
+      description: "77d0a5c6-e383-485c-b0bf-1439a1f67ae4:string:16667 CARTONS OF RED WINE",
       quantity: {
-        value: "fd190e78-8ef7-45b9-a554-527de49521c7:number:5000",
-        unit: "59a36848-f1eb-4269-b226-ef7ea6005442:string:LITRES",
+        value: "cd54295b-e569-4461-8b3d-5eae4f12f86d:number:5000",
+        unit: "c4f4b1b4-3f05-469c-9f79-8eea65cfb9e1:string:LITRES",
       },
-      countryOfOrigin: "5b6b125b-9feb-4282-8927-f134dcbe9e67:string:AUSTRALIA",
-      outwardBillNo: "c6aaaf13-4d18-4705-80e3-38edc9a24fd9:string:AQSIQ170923130",
-      dateOfDischarge: "1b019370-16e2-463a-8735-5be309540a24:string:2018-01-26",
-      dateOfDeparture: "3da430d9-8505-40fb-a077-e731649d87e2:string:2018-01-30",
-      countryOfFinalDestination: "3333b8bf-22fd-4ed2-8e25-3e139febf072:string:CHINA",
-      outgoingVehicleNo: "6667f659-e9f0-4537-ae29-378bcd65427a:string:COSCO JAPAN 074E/30-JAN",
+      countryOfOrigin: "89377474-29b7-44eb-8a2e-d2d8f4c2ba25:string:AUSTRALIA",
+      outwardBillNo: "8c8e7f1b-6ec0-429f-8536-739b149507f9:string:AQSIQ170923130",
+      dateOfDischarge: "32ef239d-d98a-4712-a40a-330d39d4db16:string:2018-01-26",
+      dateOfDeparture: "a068e31d-9f2b-4698-b4d0-69bf9181d1d6:string:2018-01-30",
+      countryOfFinalDestination: "2ef9d520-dd2c-4076-a2af-bf1e6bd9bd61:string:CHINA",
+      outgoingVehicleNo: "099c443a-c51e-4446-ae2c-0ba90d6d2510:string:COSCO JAPAN 074E/30-JAN",
     },
     declaration: {
-      name: "5d07e4ef-280d-4564-b03a-987b411ec20d:string:PETER LEE",
-      designation: "3203412b-b77c-46ad-befe-2a14e74d566c:string:SHIPPING MANAGER",
-      date: "3154e2b7-18e9-4bc3-8961-e1afc3e92b49:string:2018-01-28",
+      name: "b9915d76-bf07-427d-952d-2c77eca55cc3:string:PETER LEE",
+      designation: "d04e3577-515c-4fad-aa66-47319ce3b970:string:SHIPPING MANAGER",
+      date: "ffd492e3-88f6-4803-a2eb-1a6395197909:string:2018-01-28",
     },
   },
   signature: {
     type: "SHA3MerkleProof",
-    targetHash: "69fe778652b6a94959bc16400440c3a3dae4ce744622430e705939fafb23d01f",
+    targetHash: "d0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5",
     proof: [],
-    merkleRoot: "69fe778652b6a94959bc16400440c3a3dae4ce744622430e705939fafb23d01f",
+    merkleRoot: "d0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5",
   },
   proof: [
     {
@@ -64,7 +58,7 @@ export const documentDnsDidSigned: any = {
       proofPurpose: "assertionMethod",
       verificationMethod: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
       signature:
-        "0xcf9275ba546ccc752ff26b5e6072be661dbc066b2427760986d5aa03b108f48c3e8505d8e55c843137a9aa26f5c44a6136b5a16fce2c453b627088cd0fe194771c",
+        "0xd05bb71bdb6f78451e2d12851825421666c6c5e355f516325ce5002a0586f89f6ebbd465227bec59c745dd26918dd8dab9122dcd398256d8e487e0ecf82a53421b",
     },
   ],
 };


### PR DESCRIPTION
## Key Changes

![image](https://user-images.githubusercontent.com/7406870/91938009-c1402200-ed25-11ea-82ca-84533c902322.png)

1. Moved `id` to top level property in the `issuers`. This corresponds to how w3c vc is working now.
2. Removed other properties in the `key` block, leaving only the key id which is now the top level for `key`. 