### PR TITLE
[WIP] feat: identity verifier builder

### DIFF
--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -48,7 +48,7 @@ export type VerificationFragmentStatus = "ERROR" | "VALID" | "INVALID" | "SKIPPE
  * - a *verify* function, who must return the result of the verification as a {@link VerificationFragment}
  * - a *skip* function, who must return the result of a verification when it's skipped by providing additional data on why the validation didn't run.
  */
-interface SkippedVerificationFragment extends VerificationFragment {
+export interface SkippedVerificationFragment extends VerificationFragment {
   status: "SKIPPED";
   reason: Reason;
 }

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -61,6 +61,12 @@ export enum OpenAttestationSignatureCode {
   UNSUPPORTED_KEY_TYPE = 6,
 }
 
+export enum OpenAttestationIssuerIdentityVerifierCode {
+  SKIPPED = 0,
+  UNEXPECTED_ERROR = 1,
+  UNEXPECTED_DOCUMENT_FORMAT = 2,
+}
+
 export interface EthersError extends Error {
   reason?: string | string[];
   code?: string;

--- a/src/verifiers/identity/builder.default.test.ts
+++ b/src/verifiers/identity/builder.default.test.ts
@@ -1,11 +1,11 @@
-import { issuerIdentityVerifierBuilder, IssuerIdentityVerifier, IssuerIdentityVerifierDefinition } from "./builder";
-import dnsTxtVerifier from "./verifiers/dnsTxt/dnsTxt";
+import { issuerIdentityVerifierBuilder } from "./builder";
+import { OpenAttestationDnsTxt } from "./verifiers/dnsTxt/dnsTxt";
 
 import { documentRopstenValidWithToken } from "../../../test/fixtures/v2/documentRopstenValidWithToken";
 import { documentRopstenValidWithDocumentStore } from "../../../test/fixtures/v3/documentRopstenValid";
 
 it("works for v2", async () => {
-  const verifier = issuerIdentityVerifierBuilder([dnsTxtVerifier]);
+  const verifier = issuerIdentityVerifierBuilder([OpenAttestationDnsTxt]);
   const results = await verifier.verify(documentRopstenValidWithToken, { network: "ropsten" });
   expect(results).toMatchInlineSnapshot(`
     Object {
@@ -27,7 +27,7 @@ it("works for v2", async () => {
 });
 
 it("works for v3", async () => {
-  const verifier = issuerIdentityVerifierBuilder([dnsTxtVerifier]);
+  const verifier = issuerIdentityVerifierBuilder([OpenAttestationDnsTxt]);
   const results = await verifier.verify(
     {
       ...documentRopstenValidWithDocumentStore,

--- a/src/verifiers/identity/builder.default.test.ts
+++ b/src/verifiers/identity/builder.default.test.ts
@@ -1,0 +1,62 @@
+import { issuerIdentityVerifierBuilder, IssuerIdentityVerifier, IssuerIdentityVerifierDefinition } from "./builder";
+import dnsTxtVerifier from "./verifiers/dnsTxt/dnsTxt";
+
+import { documentRopstenValidWithToken } from "../../../test/fixtures/v2/documentRopstenValidWithToken";
+import { documentRopstenValidWithDocumentStore } from "../../../test/fixtures/v3/documentRopstenValid";
+
+it("works for v2", async () => {
+  const verifier = issuerIdentityVerifierBuilder([dnsTxtVerifier]);
+  const results = await verifier.verify(documentRopstenValidWithToken, { network: "ropsten" });
+  expect(results).toMatchInlineSnapshot(`
+    Object {
+      "data": Array [
+        Object {
+          "data": Object {
+            "smartContractAddress": "0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe",
+          },
+          "identifier": "example.tradetrust.io",
+          "status": "VALID",
+          "verifier": "OpenAttestationDnsTxt",
+        },
+      ],
+      "name": "OpenAttestationIssuerIdentityVerifier",
+      "status": "VALID",
+      "type": "ISSUER_IDENTITY",
+    }
+  `);
+});
+
+it("works for v3", async () => {
+  const verifier = issuerIdentityVerifierBuilder([dnsTxtVerifier]);
+  const results = await verifier.verify(
+    {
+      ...documentRopstenValidWithDocumentStore,
+      data: {
+        ...documentRopstenValidWithDocumentStore.data,
+        issuer: {
+          ...documentRopstenValidWithDocumentStore.data.issuer,
+          identityProof: {
+            ...documentRopstenValidWithDocumentStore.data.issuer.identityProof,
+            location: "1d337929-6770-4a05-ace0-1f07c25c7615:string:example.openattestation.com",
+          },
+        },
+      },
+    },
+    { network: "ropsten" }
+  );
+  expect(results).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "data": Object {
+          "smartContractAddress": "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+        },
+        "identifier": "example.openattestation.com",
+        "status": "VALID",
+        "verifier": "OpenAttestationDnsTxt",
+      },
+      "name": "OpenAttestationIssuerIdentityVerifier",
+      "status": "VALID",
+      "type": "ISSUER_IDENTITY",
+    }
+  `);
+});

--- a/src/verifiers/identity/builder.test.ts
+++ b/src/verifiers/identity/builder.test.ts
@@ -1,4 +1,4 @@
-import { issuerIdentityVerifierBuilder, IssuerIdentityVerifier, IssuerIdentityVerifierDefinition } from "./verifier";
+import { issuerIdentityVerifierBuilder, IssuerIdentityVerifier, IssuerIdentityVerifierDefinition } from "./builder";
 
 const mockVerify: IssuerIdentityVerifier = () => {
   return Promise.resolve({

--- a/src/verifiers/identity/builder.test.ts
+++ b/src/verifiers/identity/builder.test.ts
@@ -1,0 +1,42 @@
+import { issuerIdentityVerifierBuilder, IssuerIdentityVerifier, IssuerIdentityVerifierDefinition } from "./verifier";
+
+const mockVerify: IssuerIdentityVerifier = () => {
+  return Promise.resolve({
+    verifier: "MOCK_VERIFIER",
+    identifier: "DID:METHOD:IDENTIFIER",
+    status: "VALID",
+  });
+};
+
+const mockVerifyDef: IssuerIdentityVerifierDefinition = {
+  type: "MOCK_TYPE",
+  verify: mockVerify,
+};
+
+describe("issuerIdentityVerifierBuilder", () => {
+  it("should build a verifier with the right functions", () => {
+    const verifier = issuerIdentityVerifierBuilder([mockVerifyDef]);
+    expect(verifier.test).toBeTruthy();
+    expect(verifier.skip).toBeTruthy();
+    expect(verifier.verify).toBeTruthy();
+  });
+  it("should run for all documents", () => {
+    const verifier = issuerIdentityVerifierBuilder([mockVerifyDef]);
+    expect(verifier.test({} as any, {} as any)).toBe(true);
+  });
+  it("should return the correct skip message", async () => {
+    const verifier = issuerIdentityVerifierBuilder([mockVerifyDef]);
+    expect(await verifier.skip({} as any, {} as any)).toMatchInlineSnapshot(`
+      Object {
+        "name": "OpenAttestationIssuerIdentityVerifier",
+        "reason": Object {
+          "code": 0,
+          "codeString": "SKIPPED",
+          "message": "Verification of issuers' identity skipped",
+        },
+        "status": "SKIPPED",
+        "type": "ISSUER_IDENTITY",
+      }
+    `);
+  });
+});

--- a/src/verifiers/identity/builder.ts
+++ b/src/verifiers/identity/builder.ts
@@ -1,0 +1,133 @@
+import { v2, v3, WrappedDocument, utils, getData } from "@govtechsg/open-attestation";
+import {
+  VerificationFragmentType,
+  Verifier,
+  VerificationFragmentStatus,
+  SkippedVerificationFragment,
+} from "../../types/core";
+import { Reason } from "../../types/error";
+import { OpenAttestationIssuerIdentityVerifierCode } from "../../types/error";
+
+const name = "OpenAttestationIssuerIdentityVerifier";
+const type: VerificationFragmentType = "ISSUER_IDENTITY";
+type VerifierType = Verifier<WrappedDocument<v2.OpenAttestationDocument> | WrappedDocument<v3.OpenAttestationDocument>>;
+
+export interface VerifierResults<T = any> {
+  verifier: string; // Which verifier returned this result
+  identifier?: string; // Human readable interpretation of the issuer
+  status: VerificationFragmentStatus; // Status of this verification result
+  data?: T; // Other metadata returned by verifier
+  reason?: Reason; // Reasons for status
+}
+
+export type IssuerIdentityVerifier<
+  Document = WrappedDocument<v3.OpenAttestationDocument> | WrappedDocument<v2.OpenAttestationDocument>,
+  ResultData = any
+> = (document: Document, issuerIndex?: number) => Promise<VerifierResults<ResultData>>;
+
+export type IssuerIdentityVerifierDefinition = {
+  type: string;
+  verify: IssuerIdentityVerifier;
+};
+
+const skipFragment: SkippedVerificationFragment = {
+  status: "SKIPPED",
+  type,
+  name,
+  reason: {
+    code: OpenAttestationIssuerIdentityVerifierCode.SKIPPED,
+    codeString: OpenAttestationIssuerIdentityVerifierCode[OpenAttestationIssuerIdentityVerifierCode.SKIPPED],
+    message: `Verification of issuers' identity skipped`,
+  },
+};
+
+const defaultVerifier: IssuerIdentityVerifier = async (_, index) => {
+  return {
+    verifier: "SKIPPED_VERIFIER",
+    status: "SKIPPED",
+    reason: {
+      code: OpenAttestationIssuerIdentityVerifierCode.SKIPPED,
+      codeString: OpenAttestationIssuerIdentityVerifierCode[OpenAttestationIssuerIdentityVerifierCode.SKIPPED],
+      message: `No verifier found for issuer ${index}`,
+    },
+  };
+};
+
+export const issuerIdentityVerifierBuilder = (verifiers: IssuerIdentityVerifierDefinition[]): VerifierType => {
+  const registeredVerifiers: { [identityProofType: string]: IssuerIdentityVerifier } = {};
+  verifiers.forEach((verifier) => (registeredVerifiers[verifier.type] = verifier.verify));
+
+  const getVerifier = (identityProofType: string): IssuerIdentityVerifier =>
+    registeredVerifiers[identityProofType] || defaultVerifier;
+  const skip: VerifierType["skip"] = async () => skipFragment;
+  const test: VerifierType["test"] = () => true;
+
+  const verify: VerifierType["verify"] = async (document) => {
+    try {
+      if (utils.isWrappedV3Document(document)) {
+        const documentData = getData(document);
+        const verifier = getVerifier(documentData.issuer.identityProof.type);
+        const verificationResults = await verifier(document);
+        return {
+          name,
+          type,
+          data: verificationResults,
+          status: verificationResults.status,
+        };
+      }
+      if (utils.isWrappedV2Document(document)) {
+        const documentData = getData(document);
+        const verificationResultsDeferred = documentData.issuers.map((issuer, index) => {
+          const identityProofType = issuer.identityProof?.type;
+          if (!identityProofType) throw new Error("");
+          const verifier = getVerifier(identityProofType);
+          return verifier(document, index);
+        });
+        const verificationResults = await Promise.all(verificationResultsDeferred);
+        const overallStatus =
+          verificationResults.every((result) => result.status === "VALID") && documentData.issuers.length > 0
+            ? "VALID"
+            : "INVALID";
+        return {
+          name,
+          type,
+          data: verificationResults,
+          status: overallStatus,
+        };
+      }
+      return {
+        name,
+        type,
+        status: "INVALID",
+        reason: {
+          code: OpenAttestationIssuerIdentityVerifierCode.UNEXPECTED_DOCUMENT_FORMAT,
+          codeString:
+            OpenAttestationIssuerIdentityVerifierCode[
+              OpenAttestationIssuerIdentityVerifierCode.UNEXPECTED_DOCUMENT_FORMAT
+            ],
+          message: `Document format is unexpected`,
+        },
+      };
+    } catch (e) {
+      return {
+        name,
+        type,
+        data: e,
+        reason: {
+          message: e.message,
+          code: e.code || OpenAttestationIssuerIdentityVerifierCode.UNEXPECTED_ERROR,
+          codeString:
+            e.codeString ||
+            OpenAttestationIssuerIdentityVerifierCode[OpenAttestationIssuerIdentityVerifierCode.UNEXPECTED_ERROR],
+        },
+        status: "ERROR",
+      };
+    }
+  };
+
+  return {
+    skip,
+    test,
+    verify,
+  };
+};

--- a/src/verifiers/identity/builder.ts
+++ b/src/verifiers/identity/builder.ts
@@ -6,8 +6,7 @@ import {
   SkippedVerificationFragment,
   VerificationManagerOptions,
 } from "../../types/core";
-import { Reason } from "../../types/error";
-import { OpenAttestationIssuerIdentityVerifierCode } from "../../types/error";
+import { Reason, OpenAttestationIssuerIdentityVerifierCode } from "../../types/error";
 
 const name = "OpenAttestationIssuerIdentityVerifier";
 const type: VerificationFragmentType = "ISSUER_IDENTITY";
@@ -64,7 +63,9 @@ const defaultVerifier: IssuerIdentityVerifier = async ({ issuerIndex }) => {
 
 export const issuerIdentityVerifierBuilder = (verifiers: IssuerIdentityVerifierDefinition[]): VerifierType => {
   const registeredVerifiers: { [identityProofType: string]: IssuerIdentityVerifier } = {};
-  verifiers.forEach((verifier) => (registeredVerifiers[verifier.type] = verifier.verify));
+  verifiers.forEach((verifier) => {
+    registeredVerifiers[verifier.type] = verifier.verify;
+  });
 
   const getVerifier = (identityProofType: string): IssuerIdentityVerifier =>
     registeredVerifiers[identityProofType] || defaultVerifier;
@@ -94,7 +95,7 @@ export const issuerIdentityVerifierBuilder = (verifiers: IssuerIdentityVerifierD
         });
         const verificationResults = await Promise.all(verificationResultsDeferred);
         const overallStatus =
-          verificationResults.every((result) => result.status === "VALID") && documentData.issuers.length > 0
+          verificationResults.every((result) => result.status === "VALID") && verificationResults.length > 0
             ? "VALID"
             : "INVALID";
         return {

--- a/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
+++ b/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
@@ -3,7 +3,6 @@ import { VerificationManagerOptions } from "src/types/core";
 import { getDefaultProvider } from "ethers";
 import { getDocumentStoreRecords } from "@govtechsg/dnsprove";
 import { VerifierResults, IssuerIdentityVerifier } from "../../builder";
-import { CodedError } from "../../../../common/error";
 import { OpenAttestationDnsTxtCode } from "../../../../types/error";
 
 const verifier = "OpenAttestationDnsTxt";
@@ -18,9 +17,25 @@ const resolveIssuerIdentity = async (
   const type = issuer?.identityProof?.type ?? "";
   const identifier = issuer?.identityProof?.location ?? "";
   if (type !== "DNS-TXT")
-    throw new CodedError("Identity type not supported", OpenAttestationDnsTxtCode.INVALID_IDENTITY, "INVALID_IDENTITY");
+    return {
+      verifier,
+      status: "ERROR",
+      reason: {
+        code: OpenAttestationDnsTxtCode.INVALID_IDENTITY,
+        codeString: "INVALID_IDENTITY",
+        message: "Identity type not supported",
+      },
+    };
   if (!identifier)
-    throw new CodedError("Location is missing", OpenAttestationDnsTxtCode.INVALID_IDENTITY, "INVALID_IDENTITY");
+    return {
+      verifier,
+      status: "ERROR",
+      reason: {
+        code: OpenAttestationDnsTxtCode.INVALID_IDENTITY,
+        codeString: "INVALID_IDENTITY",
+        message: "Location is missing",
+      },
+    };
   const network = await getDefaultProvider(options.network).getNetwork();
   const records = await getDocumentStoreRecords(identifier);
   const matchingRecord = records.find(

--- a/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
+++ b/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
@@ -1,8 +1,10 @@
 import { getData, utils, v2, v3 } from "@govtechsg/open-attestation";
-import { VerifierResults, IssuerIdentityVerifier } from "../../builder";
 import { VerificationManagerOptions } from "src/types/core";
 import { getDefaultProvider } from "ethers";
 import { getDocumentStoreRecords } from "@govtechsg/dnsprove";
+import { VerifierResults, IssuerIdentityVerifier } from "../../builder";
+import { CodedError } from "../../../../common/error";
+import { OpenAttestationDnsTxtCode } from "../../../../types/error";
 
 const verifier = "OpenAttestationDnsTxt";
 
@@ -15,8 +17,10 @@ const resolveIssuerIdentity = async (
 ): Promise<VerifierResults> => {
   const type = issuer?.identityProof?.type ?? "";
   const identifier = issuer?.identityProof?.location ?? "";
-  if (type !== "DNS-TXT") throw new Error("Identity type not supported");
-  if (!identifier) throw new Error("Location is missing");
+  if (type !== "DNS-TXT")
+    throw new CodedError("Identity type not supported", OpenAttestationDnsTxtCode.INVALID_IDENTITY, "INVALID_IDENTITY");
+  if (!identifier)
+    throw new CodedError("Location is missing", OpenAttestationDnsTxtCode.INVALID_IDENTITY, "INVALID_IDENTITY");
   const network = await getDefaultProvider(options.network).getNetwork();
   const records = await getDocumentStoreRecords(identifier);
   const matchingRecord = records.find(
@@ -60,7 +64,7 @@ export const verify: IssuerIdentityVerifier = async ({ document, issuerIndex, op
   }
 };
 
-export default {
+export const OpenAttestationDnsTxt = {
   type: "DNS-TXT",
   verify,
 };

--- a/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
+++ b/src/verifiers/identity/verifiers/dnsTxt/dnsTxt.ts
@@ -1,0 +1,66 @@
+import { getData, utils, v2, v3 } from "@govtechsg/open-attestation";
+import { VerifierResults, IssuerIdentityVerifier } from "../../builder";
+import { VerificationManagerOptions } from "src/types/core";
+import { getDefaultProvider } from "ethers";
+import { getDocumentStoreRecords } from "@govtechsg/dnsprove";
+
+const verifier = "OpenAttestationDnsTxt";
+
+// Resolve identity of an issuer, currently supporting only DNS-TXT
+// DNS-TXT is explained => https://github.com/Open-Attestation/adr/blob/master/decentralized_identity_proof_DNS-TXT.md
+const resolveIssuerIdentity = async (
+  issuer: v2.Issuer | v3.Issuer,
+  smartContractAddress: string,
+  options: VerificationManagerOptions
+): Promise<VerifierResults> => {
+  const type = issuer?.identityProof?.type ?? "";
+  const identifier = issuer?.identityProof?.location ?? "";
+  if (type !== "DNS-TXT") throw new Error("Identity type not supported");
+  if (!identifier) throw new Error("Location is missing");
+  const network = await getDefaultProvider(options.network).getNetwork();
+  const records = await getDocumentStoreRecords(identifier);
+  const matchingRecord = records.find(
+    (record) =>
+      record.addr.toLowerCase() === smartContractAddress.toLowerCase() &&
+      record.netId === network.chainId.toString(10) &&
+      record.type === "openatts" &&
+      record.net === "ethereum"
+  );
+  return matchingRecord
+    ? {
+        verifier,
+        status: "VALID",
+        identifier,
+        data: { smartContractAddress },
+      }
+    : {
+        verifier,
+        status: "INVALID",
+        identifier,
+        data: { smartContractAddress },
+      };
+};
+
+export const verify: IssuerIdentityVerifier = async ({ document, issuerIndex, options }) => {
+  if (utils.isWrappedV2Document(document)) {
+    if (typeof issuerIndex === "undefined") throw new Error("issuerIndex undefined for V2 document");
+    const issuer = getData(document).issuers[issuerIndex];
+    const status = resolveIssuerIdentity(
+      issuer,
+      // we expect the test function to prevent this issue => smart contract address MUST be populated
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (issuer.documentStore || issuer.tokenRegistry || issuer.certificateStore)!,
+      options
+    );
+    return status;
+  } else {
+    const documentData = getData(document);
+    const status = await resolveIssuerIdentity(documentData.issuer, documentData.proof.value, options);
+    return status;
+  }
+};
+
+export default {
+  type: "DNS-TXT",
+  verify,
+};


### PR DESCRIPTION
## Status: Request for comments [DO NOT MERGE]

Solution for https://github.com/Open-Attestation/adr/blob/master/issuer_identity_verifier.md

Sample fragment for v2 and v3 document using DNS-TXT:
 
![image](https://user-images.githubusercontent.com/7406870/96687033-e9591280-13b1-11eb-8351-53bfe4df71ce.png)

## Notable Changes

- Mapping the issuers once only, using only one verifier `OpenAttestationIssuerIdentityVerifier`
- All issuers MUST pass their verifier, each result will return which verifier verified it (ie `OpenAttestationDnsTxt`)
- Standardizing of `identifier` to be used by dependent apps  (was `location`)
- Additional data to be parked in `data`