### PR TITLE
feat: stricter did identity

### DIFF
--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -50,6 +50,7 @@ export enum OpenAttestationDidSignedDocumentStatusCode {
 export enum OpenAttestationDidSignedDidIdentityProofCode {
   SKIPPED = 0,
   UNEXPECTED_ERROR = 1,
+  INVALID_ISSUERS = 2,
 }
 export enum OpenAttestationDnsDidCode {
   SKIPPED = 0,

--- a/src/verifiers/issuerIdentity/didIdentityProof/didIdentityProof.test.ts
+++ b/src/verifiers/issuerIdentity/didIdentityProof/didIdentityProof.test.ts
@@ -92,11 +92,16 @@ describe("verify", () => {
               "status": "VALID",
             },
             Object {
-              "status": "SKIPPED",
+              "reason": Object {
+                "code": 2,
+                "codeString": "INVALID_ISSUERS",
+                "message": "Issuer is not using DID identityProof type",
+              },
+              "status": "INVALID",
             },
           ],
           "name": "OpenAttestationDidSignedDidIdentityProof",
-          "status": "VALID",
+          "status": "INVALID",
           "type": "ISSUER_IDENTITY",
         }
       `);

--- a/src/verifiers/issuerIdentity/didIdentityProof/didIdentityProof.ts
+++ b/src/verifiers/issuerIdentity/didIdentityProof/didIdentityProof.ts
@@ -48,7 +48,15 @@ const verify: VerifierType["verify"] = withCodedErrorHandler(
         });
         return { did, status: verified ? "VALID" : "INVALID" };
       }
-      return { status: "SKIPPED" };
+      return {
+        status: "INVALID",
+        reason: {
+          message: "Issuer is not using DID identityProof type",
+          code: OpenAttestationDidSignedDidIdentityProofCode.INVALID_ISSUERS,
+          codeString:
+            OpenAttestationDidSignedDidIdentityProofCode[OpenAttestationDidSignedDidIdentityProofCode.INVALID_ISSUERS],
+        },
+      };
     });
     const signatureVerifications = await Promise.all(signatureVerificationDeferred);
     const signedOnAll =


### PR DESCRIPTION
- disallowing "SKIPPED" status on `didIdentityProof` & letting it fail on mixture of `identityProof.type`
- refactored error handling to use `withCodedErrorHandler`