### PR TITLE
feat: stricter dns did identity

### DIFF
--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -56,6 +56,7 @@ export enum OpenAttestationDnsDidCode {
   SKIPPED = 0,
   UNEXPECTED_ERROR = 1,
   MALFORMED_IDENTITY_PROOF = 2,
+  INVALID_ISSUERS = 3,
 }
 export enum OpenAttestationSignatureCode {
   UNEXPECTED_ERROR = 0,

--- a/src/verifiers/issuerIdentity/dnsDidProof/dnsDidProof.test.ts
+++ b/src/verifiers/issuerIdentity/dnsDidProof/dnsDidProof.test.ts
@@ -92,11 +92,16 @@ describe("verify", () => {
             "status": "VALID",
           },
           Object {
-            "status": "SKIPPED",
+            "reason": Object {
+              "code": 3,
+              "codeString": "INVALID_ISSUERS",
+              "message": "Issuer is not using DID identityProof type",
+            },
+            "status": "INVALID",
           },
         ],
         "name": "OpenAttestationDnsDid",
-        "status": "VALID",
+        "status": "INVALID",
         "type": "ISSUER_IDENTITY",
       }
     `);
@@ -111,7 +116,12 @@ describe("verify", () => {
             "status": "INVALID",
           },
           Object {
-            "status": "SKIPPED",
+            "reason": Object {
+              "code": 3,
+              "codeString": "INVALID_ISSUERS",
+              "message": "Issuer is not using DID identityProof type",
+            },
+            "status": "INVALID",
           },
         ],
         "name": "OpenAttestationDnsDid",

--- a/src/verifiers/issuerIdentity/dnsDidProof/dnsDidProof.ts
+++ b/src/verifiers/issuerIdentity/dnsDidProof/dnsDidProof.ts
@@ -77,7 +77,12 @@ const verify: VerifierType["verify"] = withCodedErrorHandler(
     const deferredVerificationStatus: Promise<VerificationFragment>[] = documentData.issuers.map((issuer) => {
       if (issuer.identityProof?.type === "DNS-DID") return verifyIssuerDnsDid(issuer.identityProof);
       return Promise.resolve({
-        status: "SKIPPED",
+        status: "INVALID",
+        reason: {
+          message: "Issuer is not using DID identityProof type",
+          code: OpenAttestationDnsDidCode.INVALID_ISSUERS,
+          codeString: OpenAttestationDnsDidCode[OpenAttestationDnsDidCode.INVALID_ISSUERS],
+        },
       });
     });
     const verificationStatus = await Promise.all(deferredVerificationStatus);


### PR DESCRIPTION
- refactored to use `withCodedErrorHandler`
- changing `SKIPPED` to `INVALID` on mixture of `identityProof.type`