### PR TITLE
feat: add getIdentifier and getIdentityFragment util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .idea
 *.iml
 .DS_Store
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ethers": "^5.0.4",
         "ethr-did-resolver": "^3.0.0",
         "node-cache": "^5.1.2",
+        "runtypes": "^5.0.1",
         "snyk": "^1.364.2",
         "web-did-resolver": "^1.3.3"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ethers": "^5.0.4",
     "ethr-did-resolver": "^3.0.0",
     "node-cache": "^5.1.2",
+    "runtypes": "^5.0.1",
     "snyk": "^1.364.2",
     "web-did-resolver": "^1.3.3"
   },

--- a/src/getIdentifier.test.ts
+++ b/src/getIdentifier.test.ts
@@ -84,23 +84,20 @@ const malformedVerificationFragment2: VerificationFragment = {
   status: "VALID",
 };
 
-
 describe("getIdentifier", () => {
   it("should throw an error when no fragments are provided", () => {
     expect(() => getIdentifier([])).toThrowError("Please provide at least one verification fragment");
   });
   it("should return an unknown identity proof, when fragment.name is out of specification", () => {
-    expect(
-      getIdentifier([verificationFragment1, malformedVerificationFragment1])
-    ).toStrictEqual({
+    expect(getIdentifier([verificationFragment1, malformedVerificationFragment1])).toStrictEqual({
       identifier: "Unknown",
       type: "Unknown",
     });
   });
   it("should throw an error when fragment.data cannot be handled", () => {
-    expect(() =>
-      getIdentifier([verificationFragment1, malformedVerificationFragment2]))
-    .toThrowError("No data property found in fragment, malformed fragment");
+    expect(() => getIdentifier([verificationFragment1, malformedVerificationFragment2])).toThrowError(
+      "No data property found in fragment, malformed fragment"
+    );
   });
 
   describe("v2", () => {

--- a/src/getIdentifier.test.ts
+++ b/src/getIdentifier.test.ts
@@ -1,5 +1,5 @@
 import { v3 } from "@govtechsg/open-attestation";
-import { getIdentityProofFragment, getIdentifier } from "./getIdentifier";
+import { getIdentifier } from "./getIdentifier";
 import { VerificationFragment } from "./types/core";
 import {
   openAttestationDnsTxtIdentityProof,
@@ -65,12 +65,18 @@ const verificationFragment4: VerificationFragment = {
   ],
   status: "VALID",
 };
+/**
+ * this fragment is malformed because the fragment's name is Unknown
+ */
 const malformedVerificationFragment1: VerificationFragment = {
   name: "Unknown",
   type: "ISSUER_IDENTITY",
   data: [],
   status: "VALID",
 };
+/**
+ * this fragment is malformed because the fragment's data is undefined
+ */
 const malformedVerificationFragment2: VerificationFragment = {
   name: "OpenAttestationDnsDidIdentityProof",
   type: "ISSUER_IDENTITY",
@@ -78,21 +84,14 @@ const malformedVerificationFragment2: VerificationFragment = {
   status: "VALID",
 };
 
-describe("getIdentityProofFragment", () => {
-  it("should throw an error when no fragments are provided", () => {
-    expect(() => getIdentityProofFragment([])).toThrowError("Please provide at least one verification fragment");
-  });
-});
 
 describe("getIdentifier", () => {
-  it("should throw an error when undefined is passed as a fragment", () => {
-    expect(() => getIdentifier(getIdentityProofFragment([verificationFragment1]))).toThrowError(
-      "Did not find any Issuer Identity fragment that is valid"
-    );
+  it("should throw an error when no fragments are provided", () => {
+    expect(() => getIdentifier([])).toThrowError("Please provide at least one verification fragment");
   });
   it("should return an unknown identity proof, when fragment.name is out of specification", () => {
     expect(
-      getIdentifier(getIdentityProofFragment([verificationFragment1, malformedVerificationFragment1]))
+      getIdentifier([verificationFragment1, malformedVerificationFragment1])
     ).toStrictEqual({
       identifier: "Unknown",
       type: "Unknown",
@@ -100,25 +99,25 @@ describe("getIdentifier", () => {
   });
   it("should throw an error when fragment.data cannot be handled", () => {
     expect(() =>
-      getIdentifier(getIdentityProofFragment([verificationFragment1, malformedVerificationFragment2]))
-    ).toThrowError("No data property found in fragment, malformed fragment");
+      getIdentifier([verificationFragment1, malformedVerificationFragment2]))
+    .toThrowError("No data property found in fragment, malformed fragment");
   });
 
   describe("v2", () => {
     it("should return a DNS identity proof if issuer fragment is of type OpenAttestationDnsTxtIdentityProof", () => {
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment2]))).toContainEqual({
+      expect(getIdentifier([verificationFragment1, verificationFragment2])).toContainEqual({
         identifier: "example.openattestation.com",
         type: "DNS",
       });
     });
     it("should return a DNS-DID identity proof if issuer fragment is of type OpenAttestationDnsDidIdentityProof", () => {
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment3]))).toContainEqual({
+      expect(getIdentifier([verificationFragment1, verificationFragment3])).toContainEqual({
         identifier: "example.tradetrust.io",
         type: "DNS-DID",
       });
     });
     it("should return a DID identity proof if issuer fragment is of type OpenAttestationDidIdentityProof", () => {
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment4]))).toContainEqual({
+      expect(getIdentifier([verificationFragment1, verificationFragment4])).toContainEqual({
         identifier: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
         type: "DID",
       });
@@ -128,21 +127,21 @@ describe("getIdentifier", () => {
   describe("v3", () => {
     it("should return a DNS identity proof if issuer fragment is of type OpenAttestationDnsTxtIdentityProof", async () => {
       const fragment = await openAttestationDnsTxtIdentityProof.verify(v3DocumentStoreIssued, options);
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+      expect(getIdentifier([verificationFragment1, fragment])).toStrictEqual({
         identifier: "example.tradetrust.io",
         type: "DNS",
       });
     });
     it("should return a DNS-DID identity proof if issuer fragment is of type OpenAttestationDnsDidIdentityProof", async () => {
       const fragment = await openAttestationDnsDidIdentityProof.verify(v3DnsDidSigned, options);
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+      expect(getIdentifier([verificationFragment1, fragment])).toStrictEqual({
         identifier: "example.tradetrust.io",
         type: "DNS-DID",
       });
     });
     it("should return a DID identity proof if issuer fragment is of type OpenAttestationDidIdentityProof", async () => {
       const fragment = await openAttestationDidIdentityProof.verify(v3DidSigned, options);
-      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+      expect(getIdentifier([verificationFragment1, fragment])).toStrictEqual({
         identifier: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
         type: "DID",
       });

--- a/src/getIdentifier.test.ts
+++ b/src/getIdentifier.test.ts
@@ -1,0 +1,151 @@
+import { v3 } from "@govtechsg/open-attestation";
+import { getIdentityProofFragment, getIdentifier } from "./getIdentifier";
+import { VerificationFragment } from "./types/core";
+import {
+  openAttestationDnsTxtIdentityProof,
+  openAttestationDnsDidIdentityProof,
+  openAttestationDidIdentityProof,
+} from ".";
+import { getProvider } from "./common/utils";
+
+import v3DidSignedRaw from "../test/fixtures/v3/did-signed.json";
+import v3DnsDidSignedRaw from "../test/fixtures/v3/dnsdid-signed.json";
+import v3DocumentStoreIssuedRaw from "../test/fixtures/v3/documentStore-issued.json";
+
+const v3DidSigned = v3DidSignedRaw as v3.SignedWrappedDocument;
+const v3DnsDidSigned = v3DnsDidSignedRaw as v3.SignedWrappedDocument;
+const v3DocumentStoreIssued = v3DocumentStoreIssuedRaw as v3.WrappedDocument;
+
+const options = {
+  provider: getProvider({ network: "ropsten" }),
+};
+
+const verificationFragment1: VerificationFragment = {
+  status: "SKIPPED",
+  type: "DOCUMENT_STATUS",
+  name: "OpenAttestationDidSignedDocumentStatus",
+  reason: {
+    code: 0,
+    codeString: "SKIPPED",
+    message: "Document was not signed by DID directly",
+  },
+};
+const verificationFragment2: VerificationFragment = {
+  name: "OpenAttestationDnsTxtIdentityProof",
+  type: "ISSUER_IDENTITY",
+  data: [
+    {
+      status: "VALID",
+      location: "example.openattestation.com",
+      value: "0x2f60375e8144e16Adf1979936301D8341D58C36C",
+    },
+  ],
+  status: "VALID",
+};
+const verificationFragment3: VerificationFragment = {
+  name: "OpenAttestationDnsDidIdentityProof",
+  type: "ISSUER_IDENTITY",
+  data: [
+    {
+      location: "example.tradetrust.io",
+      key: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+      status: "VALID",
+    },
+  ],
+  status: "VALID",
+};
+const verificationFragment4: VerificationFragment = {
+  name: "OpenAttestationDidIdentityProof",
+  type: "ISSUER_IDENTITY",
+  data: [
+    {
+      did: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      status: "VALID",
+    },
+  ],
+  status: "VALID",
+};
+const malformedVerificationFragment1: VerificationFragment = {
+  name: "Unknown",
+  type: "ISSUER_IDENTITY",
+  data: [],
+  status: "VALID",
+};
+const malformedVerificationFragment2: VerificationFragment = {
+  name: "OpenAttestationDnsDidIdentityProof",
+  type: "ISSUER_IDENTITY",
+  data: undefined,
+  status: "VALID",
+};
+
+describe("getIdentityProofFragment", () => {
+  it("should throw an error when no fragments are provided", () => {
+    expect(() => getIdentityProofFragment([])).toThrowError("Please provide at least one verification fragment");
+  });
+});
+
+describe("getIdentifier", () => {
+  it("should throw an error when undefined is passed as a fragment", () => {
+    expect(() => getIdentifier(getIdentityProofFragment([verificationFragment1]))).toThrowError(
+      "Did not find any Issuer Identity fragment that is valid"
+    );
+  });
+  it("should return an unknown identity proof, when fragment.name is out of specification", () => {
+    expect(
+      getIdentifier(getIdentityProofFragment([verificationFragment1, malformedVerificationFragment1]))
+    ).toStrictEqual({
+      identifier: "Unknown",
+      type: "Unknown",
+    });
+  });
+  it("should throw an error when fragment.data cannot be handled", () => {
+    expect(() =>
+      getIdentifier(getIdentityProofFragment([verificationFragment1, malformedVerificationFragment2]))
+    ).toThrowError("No data property found in fragment, malformed fragment");
+  });
+
+  describe("v2", () => {
+    it("should return a DNS identity proof if issuer fragment is of type OpenAttestationDnsTxtIdentityProof", () => {
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment2]))).toContainEqual({
+        identifier: "example.openattestation.com",
+        type: "DNS",
+      });
+    });
+    it("should return a DNS-DID identity proof if issuer fragment is of type OpenAttestationDnsDidIdentityProof", () => {
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment3]))).toContainEqual({
+        identifier: "example.tradetrust.io",
+        type: "DNS-DID",
+      });
+    });
+    it("should return a DID identity proof if issuer fragment is of type OpenAttestationDidIdentityProof", () => {
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, verificationFragment4]))).toContainEqual({
+        identifier: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        type: "DID",
+      });
+    });
+  });
+
+  describe("v3", () => {
+    it("should return a DNS identity proof if issuer fragment is of type OpenAttestationDnsTxtIdentityProof", async () => {
+      const fragment = await openAttestationDnsTxtIdentityProof.verify(v3DocumentStoreIssued, options);
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+        identifier: "example.tradetrust.io",
+        type: "DNS",
+      });
+    });
+    it("should return a DNS-DID identity proof if issuer fragment is of type OpenAttestationDnsDidIdentityProof", async () => {
+      const fragment = await openAttestationDnsDidIdentityProof.verify(v3DnsDidSigned, options);
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+        identifier: "example.tradetrust.io",
+        type: "DNS-DID",
+      });
+    });
+    it("should return a DID identity proof if issuer fragment is of type OpenAttestationDidIdentityProof", async () => {
+      const fragment = await openAttestationDidIdentityProof.verify(v3DidSigned, options);
+      expect(getIdentifier(getIdentityProofFragment([verificationFragment1, fragment]))).toStrictEqual({
+        identifier: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        type: "DID",
+      });
+    });
+  });
+});

--- a/src/getIdentifier.ts
+++ b/src/getIdentifier.ts
@@ -62,14 +62,15 @@ const getDidIdentifierProof = (
   };
 };
 
-export const getIdentityProofFragment = (fragments: VerificationFragment[]) => {
+const getIdentityProofFragment = (fragments: VerificationFragment[]) => {
   if (fragments.length < 1) {
     throw new Error("Please provide at least one verification fragment");
   }
   return fragments.find((status) => status.type === "ISSUER_IDENTITY" && status.status === "VALID");
 };
 
-export const getIdentifier = (fragment: ReturnType<typeof getIdentityProofFragment>) => {
+export const getIdentifier = (fragments: VerificationFragment[]) => {
+  const fragment = getIdentityProofFragment(fragments);
   if (!fragment) {
     throw new Error("Did not find any Issuer Identity fragment that is valid");
   }

--- a/src/getIdentifier.ts
+++ b/src/getIdentifier.ts
@@ -1,0 +1,92 @@
+import { Record, String, Static } from "runtypes";
+import { VerificationFragment } from "./types/core";
+import { Identity } from "./verifiers/issuerIdentity/dnsTxt";
+import { SignatureVerificationFragment } from "./verifiers/issuerIdentity/did";
+import { DnsVerificationFragment } from "./verifiers/issuerIdentity/dnsDid";
+
+enum IdentityProof {
+  DNS = "OpenAttestationDnsTxtIdentityProof",
+  DNSDID = "OpenAttestationDnsDidIdentityProof",
+  DID = "OpenAttestationDidIdentityProof",
+}
+
+const DataDnsIdentifier = Record({
+  identifier: String,
+  value: String,
+});
+type DataDnsIdentifier = Static<typeof DataDnsIdentifier>;
+
+const getDnsIdentifierProof = (fragment: VerificationFragment<DataDnsIdentifier | Identity[]>) => {
+  const type = "DNS";
+  if (Array.isArray(fragment.data)) {
+    return fragment.data.map((issuer: Identity) => ({
+      identifier: issuer.location,
+      type,
+    }));
+  }
+  return {
+    identifier: fragment.data?.identifier,
+    type,
+  };
+};
+
+const getDnsDidIdentifierProof = (
+  fragment: VerificationFragment<DnsVerificationFragment | DnsVerificationFragment[]>
+) => {
+  const type = "DNS-DID";
+  if (Array.isArray(fragment.data)) {
+    return fragment.data.map((issuer: DnsVerificationFragment) => ({
+      identifier: issuer.location,
+      type,
+    }));
+  }
+  return {
+    identifier: fragment.data?.location,
+    type,
+  };
+};
+
+const getDidIdentifierProof = (
+  fragment: VerificationFragment<SignatureVerificationFragment | SignatureVerificationFragment[]>
+) => {
+  const type = "DID";
+  if (Array.isArray(fragment.data)) {
+    return fragment.data.map((issuer: SignatureVerificationFragment) => ({
+      identifier: issuer.did,
+      type,
+    }));
+  }
+  return {
+    identifier: fragment.data?.did,
+    type,
+  };
+};
+
+export const getIdentityProofFragment = (fragments: VerificationFragment[]) => {
+  if (fragments.length < 1) {
+    throw new Error("Please provide at least one verification fragment");
+  }
+  return fragments.find((status) => status.type === "ISSUER_IDENTITY" && status.status === "VALID");
+};
+
+export const getIdentifier = (fragment: ReturnType<typeof getIdentityProofFragment>) => {
+  if (!fragment) {
+    throw new Error("Did not find any Issuer Identity fragment that is valid");
+  }
+  if (!fragment.data) {
+    throw new Error("No data property found in fragment, malformed fragment");
+  }
+  switch (fragment.name) {
+    case IdentityProof.DNS:
+      return getDnsIdentifierProof(fragment);
+    case IdentityProof.DNSDID:
+      return getDnsDidIdentifierProof(fragment);
+    case IdentityProof.DID:
+      return getDidIdentifierProof(fragment);
+    default:
+      return {
+        identifier: "Unknown",
+        type: "Unknown",
+      };
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { openAttestationDidSignedDocumentStatus } from "./verifiers/documentStat
 import { Identity, openAttestationDnsTxtIdentityProof } from "./verifiers/issuerIdentity/dnsTxt";
 import { openAttestationDidIdentityProof } from "./verifiers/issuerIdentity/did";
 import { openAttestationDnsDidIdentityProof } from "./verifiers/issuerIdentity/dnsDid";
-import { getIdentifier, getIdentityProofFragment } from "./getIdentifier";
+import { getIdentifier } from "./getIdentifier";
 
 const openAttestationVerifiers: Verifiers[] = [
   openAttestationHash,
@@ -47,6 +47,5 @@ export {
   openAttestationDnsTxtIdentityProof,
   openAttestationDnsDidIdentityProof,
   openAttestationDidIdentityProof,
-  getIdentityProofFragment,
   getIdentifier,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { openAttestationDidSignedDocumentStatus } from "./verifiers/documentStat
 import { Identity, openAttestationDnsTxtIdentityProof } from "./verifiers/issuerIdentity/dnsTxt";
 import { openAttestationDidIdentityProof } from "./verifiers/issuerIdentity/did";
 import { openAttestationDnsDidIdentityProof } from "./verifiers/issuerIdentity/dnsDid";
+import { getIdentifier, getIdentityProofFragment } from "./getIdentifier";
 
 const openAttestationVerifiers: Verifiers[] = [
   openAttestationHash,
@@ -46,4 +47,6 @@ export {
   openAttestationDnsTxtIdentityProof,
   openAttestationDnsDidIdentityProof,
   openAttestationDidIdentityProof,
+  getIdentityProofFragment,
+  getIdentifier,
 };

--- a/src/verifiers/issuerIdentity/did/didIdentityProof.ts
+++ b/src/verifiers/issuerIdentity/did/didIdentityProof.ts
@@ -33,7 +33,7 @@ const test: VerifierType["test"] = (document) => {
   return false;
 };
 
-interface SignatureVerificationFragment {
+export interface SignatureVerificationFragment {
   status: string;
   did?: string;
 }

--- a/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
+++ b/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
@@ -37,7 +37,7 @@ const test: VerifierType["test"] = (document) => {
   }
   return false;
 };
-interface DnsVerificationFragment {
+export interface DnsVerificationFragment {
   status: VerificationFragmentStatus;
   location?: string;
   key?: string;


### PR DESCRIPTION
context: https://www.pivotaltracker.com/story/show/176797200
this pr does the following:
- adds `getIdentifier` and `getIdentityFragment` utils
- adds istanbul coverage folder to .gitignore