### PR TITLE
fix: pin ethr-did-resolver to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7413,12 +7413,12 @@
       "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
     },
     "ethr-did-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-3.0.0.tgz",
-      "integrity": "sha512-o400l9p8ee6W09fZLMX2BERcyFRrebE7DCjb46Rzgypb7QzX1rBOzHJ0PorWRINXFqoPMoxR7OeIrD17obIbng==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-3.0.3.tgz",
+      "integrity": "sha512-bqpA8Cs4701v0ag4w9cksdNTaCwDItNmNuHwfKgZkDhnPOEJfxvhQO75kr0RiCxM6cr9URiD9/6+FQ53+tSbvw==",
       "requires": {
-        "buffer": "^5.1.0",
-        "did-resolver": "2.1.1",
+        "buffer": "^6.0.0",
+        "did-resolver": "2.1.2",
         "elliptic": "^6.5.3",
         "ethjs-abi": "^0.2.1",
         "ethjs-contract": "^0.2.0",
@@ -7426,6 +7426,27 @@
         "ethjs-query": "^0.3.5",
         "ethr-did-registry": "^0.0.3",
         "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "did-resolver": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.2.tgz",
+          "integrity": "sha512-n4YGS1CzbX48U/ChLRY3SdgiV5N3B/+yh0ToS5t+Sx4QjhVZN6ZyijUSSYbFGvz+I4qImeSZOdo6RX8JaieN7A=="
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        }
       }
     },
     "event-loop-spinner": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^4.1.1",
     "did-resolver": "^2.1.1",
     "ethers": "^5.0.4",
-    "ethr-did-resolver": "^3.0.0",
+    "ethr-did-resolver": "3.0.3",
     "node-cache": "^5.1.2",
     "runtypes": "^5.2.0",
     "snyk": "^1.364.2",


### PR DESCRIPTION
there is an interface change in ethr-did-resolver 3.0.3 to 3.1.0, which causes resolving a public key to break.
this fix pins the dependency to 3.0.3.