### PR TITLE
chroe: move snyk to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ethr-did-resolver": "^4.3.3",
     "node-cache": "^5.1.2",
     "runtypes": "^6.3.0",
-    "snyk": "^1.576.0",
     "web-did-resolver": "^2.0.4"
   },
   "devDependencies": {
@@ -60,7 +59,8 @@
     "prettier": "^2.2.1",
     "semantic-release": "^17.4.2",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "snyk": "^1.576.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Right now, snyk is added as a direct dependency. This increases the size of the oa-verify library [by at least 20mb](https://www.npmjs.com/package/snyk).

I moved snyk dependency to a devDepency.

# To test
```
npm i
npm run snyk-protect
``` 