### PR TITLE
fix: import path from document store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1377,9 +1377,9 @@
       }
     },
     "@govtechsg/document-store": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.2.2.tgz",
-      "integrity": "sha512-JsY+f9kiji1dhOi6H77ji8oj/BZ0KBJVD3VuLHXOsBaieJDwPNzmJpe0r9NSqnV1WxfA2s0U0RhxqTLKUdFtYw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.2.3.tgz",
+      "integrity": "sha512-d6D8ku4aCmdPaxHlU8OMwqIa0WHMZ02ZzUvYujlM/FInxTfKU1jUiAA4Jdx54D60hvhvGlBYU8T9jUsTZhBY4g==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@govtechsg/dnsprove": "^2.1.3",
-    "@govtechsg/document-store": "^2.2.2",
+    "@govtechsg/document-store": "^2.2.3",
     "@govtechsg/open-attestation": "^6.0.5",
     "@govtechsg/token-registry": "^2.5.3",
     "axios": "^0.21.1",

--- a/src/verifiers/documentStatus/utils.ts
+++ b/src/verifiers/documentStatus/utils.ts
@@ -1,5 +1,5 @@
 import { utils } from "@govtechsg/open-attestation";
-import { DocumentStore } from "@govtechsg/document-store/src/contracts/DocumentStore";
+import { DocumentStore } from "@govtechsg/document-store";
 import { errors, providers } from "ethers";
 import { DocumentStoreFactory } from "@govtechsg/document-store";
 import { Hash } from "../../types/core";


### PR DESCRIPTION
## Summary
Update document-store package so as to fix the import path for `DocumentStore`. Related to https://github.com/Open-Attestation/document-store/pull/99.

## Changes
* Bump document-store version
* Update `DocumentStore` import path
