### PR TITLE
fix: verify issuer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ import { isValid } from "./validator";
 import { openAttestationEthereumTokenRegistryStatus } from "./verifiers/documentStatus/tokenRegistry";
 import { openAttestationEthereumDocumentStoreStatus } from "./verifiers/documentStatus/documentStore";
 import { openAttestationDidSignedDocumentStatus } from "./verifiers/documentStatus/didSigned";
-import { openAttestationDnsTxtIdentityProof } from "./verifiers/issuerIdentity/dnsTxt";
-import { openAttestationDidIdentityProof } from "./verifiers/issuerIdentity/did";
-import { openAttestationDnsDidIdentityProof } from "./verifiers/issuerIdentity/dnsDid";
+import { openAttestationDnsTxtIdentityProof, verifyIssuerDnsTxt } from "./verifiers/issuerIdentity/dnsTxt";
+import { openAttestationDidIdentityProof, verifyIssuerDid } from "./verifiers/issuerIdentity/did";
+import { openAttestationDnsDidIdentityProof, verifyIssuerDnsDid } from "./verifiers/issuerIdentity/dnsDid";
 import { createResolver } from "./did/resolver";
 import { getIdentifier } from "./getIdentifier";
 import * as utils from "./common/utils";
@@ -57,4 +57,7 @@ export {
   createResolver,
   getIdentifier,
   utils,
+  verifyIssuerDnsTxt,
+  verifyIssuerDnsDid,
+  verifyIssuerDid,
 };

--- a/src/verifiers/issuerIdentity/did/didIdentityProof.ts
+++ b/src/verifiers/issuerIdentity/did/didIdentityProof.ts
@@ -40,6 +40,17 @@ const test: VerifierType["test"] = (document) => {
   return false;
 };
 
+/**
+ * Returns the status object if txt record exists on domain name.
+ * DID IdentityProofType.
+ * @param key DID Public key with `did:ethr:` prefix and `#controller` suffix
+ * @param merkleRoot Merkle root value in wrapped document
+ * @param did DID Public key with `did:ethr:` prefix
+ * @param signature `signature` value of `proof` in wrapped document
+ * @param resolver Resolver for DID documents
+ */
+export const verifyIssuerDid = verifySignature;
+
 const verifyV2 = async (
   document: v2.WrappedDocument,
   options: VerifierOptions

--- a/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
+++ b/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
@@ -38,7 +38,13 @@ const test: VerifierType["test"] = (document) => {
   return false;
 };
 
-const verifyIssuerDnsDid = async ({
+/**
+ * Returns the status object if txt record exists on domain name.
+ * DNS-DID IdentityProofType.
+ * @param key DID Public key with `did:ethr:` prefix and `#controller` suffix
+ * @param location Domain name
+ */
+export const verifyIssuerDnsDid = async ({
   key,
   location,
 }: {


### PR DESCRIPTION
- reuse and export functions to verify issuer of various `IdentityProofType`
- use case = to validate txt records, to fail / disable UI early if not exists

say something like this for creator (not designed yet):

![disabled](https://user-images.githubusercontent.com/4774314/148868729-a95c01df-d21d-46d2-89e0-1b50c1149116.png)
