### PR TITLE
fix: false positive for warnProvider message

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,7 +19,6 @@ import {
   OpenAttestationEthereumDocumentStoreStatusCode,
   OpenAttestationEthereumTokenRegistryStatusCode,
 } from "../types/error";
-import { warnProvider } from "../common/messages";
 
 export const getDefaultProvider = (options: VerificationBuilderOptionsWithNetwork): providers.Provider => {
   const network = options.network || process.env.PROVIDER_NETWORK || "homestead";
@@ -65,7 +64,6 @@ export const generateProvider = (options?: ProviderDetails): providers.Provider 
   const url = options?.url || process.env.PROVIDER_ENDPOINT_URL || "";
   const apiKey =
     options?.apiKey || (provider === "infura" && process.env.INFURA_API_KEY) || process.env.PROVIDER_API_KEY || "";
-  !apiKey && console.warn(warnProvider);
 
   if (!!options && Object.keys(options).length === 1 && url) {
     return new providers.JsonRpcProvider(url);


### PR DESCRIPTION
As [suggested](https://docs.tradetrust.io/docs/appendix/tradetrust-api/#verify-endpoint), I was trying to setup my own version of the oa-verify api. I'm trying to target the Goerli test network, since Ropsten and Rinkeby will become deprecated in the future. (See [this](https://ethereum-magicians.org/t/og-council-post-merge-testnets/9034) for more info). 

I did come across the same issue as @HJunyuan described [here](https://github.com/Open-Attestation/oa-verify/issues/223). I looked at the logic of the code and I think just removing the warning message will fix the false positive. Feel free to correct/comment if removing this line has any other side effects for the package! 😄 

Fixes #223 