### PR TITLE
fix: false positive warning in verificationBuilder

### DIFF
--- a/src/verifiers/verificationBuilder.ts
+++ b/src/verifiers/verificationBuilder.ts
@@ -17,19 +17,17 @@ import { warnProvider } from "../common/messages";
  * Before running each verifier, the manager will make sure the verifier can handle the specific document by calling its exposed test function.
  * The manager will return the consolidated list of {@link VerificationFragment}
  */
-let displayWarning = true;
 export const verificationBuilder = <T extends Verifier<any>>(
   verifiers: T[],
   builderOptions: VerificationBuilderOptions
 ) => (document: DocumentsToVerify, promisesCallback?: PromiseCallback): Promise<VerificationFragment[]> => {
   // if the user didn't configure an API key and didn't configure a provider or a resolver, then he will likely use a development key. We then warn him once, that he may need to configure things properly, especially for production
   if (
-    displayWarning &&
-    (!builderOptions.resolver || !builderOptions.provider) &&
+    !builderOptions.resolver &&
+    !builderOptions.provider &&
     !process.env.INFURA_API_KEY &&
     !process.env.PROVIDER_API_KEY
   ) {
-    displayWarning = false;
     console.warn(warnProvider);
   }
   const verifierOptions: VerifierOptions = {


### PR DESCRIPTION
Related to this [PR](https://github.com/Open-Attestation/oa-verify/pull/232) and [issue](https://github.com/Open-Attestation/oa-verify/issues/223), was still receiving the `warnProvider` message, even though I configured a full custom provider.

I played around with the package and I think this small logic change will also fix this false positive warning for the verificationBuilder. It will still give the warning if you are using the default provider, but not when you configured your own provider or resolver now! 😄 