### PR TITLE
feat: bump dnsprove version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,9 +2142,9 @@
       }
     },
     "@govtechsg/dnsprove": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.3.0.tgz",
-      "integrity": "sha512-d8nmtlk8xbM7tR/7sKJcz1cL5yRLDxLysbzO5JTohj2grRij4jKyHwcEyfVTX5up6zXv2ELFcsu0zyvRuVVXFA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.5.0.tgz",
+      "integrity": "sha512-aUrLPF1DeydxKRJsLW++vQoTGXkUoP8zbHwaUU63vFar7pBZ/1UIWr/QJlYGmyVgZ++eQlHeKaiC+Zp3ix2Qag==",
       "requires": {
         "axios": "^0.21.1",
         "debug": "^4.3.1",
@@ -16521,7 +16521,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@govtechsg/dnsprove": "^2.3.0",
+    "@govtechsg/dnsprove": "^2.5.0",
     "@govtechsg/document-store": "^2.2.3",
     "@govtechsg/open-attestation": "^6.2.0",
     "@govtechsg/token-registry": "^2.5.3",


### PR DESCRIPTION
## Summary
Bump version for dnsprove.

## Changes
* Update dnsprove package to `^2.5.0`

## Issues
* https://github.com/Open-Attestation/dnsprove/pull/28
* https://github.com/Open-Attestation/dnsprove/pull/29
* https://www.pivotaltracker.com/story/show/183221914
* https://www.pivotaltracker.com/story/show/183222257