### PR TITLE
fix: exports path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "@govtechsg/oa-verify",
   "version": "0.0.0-development",
   "description": "",
-  "type": "commonjs",
-  "source": "src/index.ts",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.js",
   "module": "dist/index.module.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "import": "./dist/index.modern.mjs",
+    "default": "./dist/index.modern.mjs",
+    "types": "./dist/types/index.d.ts"
   },
-  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "npm run clean && microbundle --tsconfig tsconfig.prod.json",
     "clean": "rm -rf dist/",


### PR DESCRIPTION
## Summary

End-users are not able to import the `oa-verify` library successfully:
- `type: "commonjs"` was conflicting with instruction to export as module causing end-users will face this error:
    ```text
    Module parse failed: 'import' and 'export' may appear only with 'sourceType: module'
    ```
- Typo on `exports.default` path 

## Changes

- Remove `type` and `source`
- Fix `exports.default` file path (was missing `m` previously)
- Add `exports.import` and `exports.types` file path

```jsonc
{
  // ...
  "exports": {
    "require": "./dist/index.js",
    "import": "./dist/index.modern.mjs",
    "default": "./dist/index.modern.mjs",
    "types": "./dist/types/index.d.ts"
  },
  // ...
}
```