### PR TITLE
ci: set PROVIDER_API_KEY from GitHub repository variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 18.x
       - run: npm ci
       - run: npm run test:ci
+        env:
+          PROVIDER_API_KEY: ${{ vars.PROVIDER_API_KEY }}
 
   test-build:
     name: Test Build


### PR DESCRIPTION
## Context

GitHub Actions workflow (`.github/workflows/tests.yml`) keeps failing when running `npm run test:ci`. Probably due to not specifying an Infura API key or the default one is being overused?

## What does this PR do?

Set a `PROVIDER_API_KEY` env var specifically when running `npm run test:ci`