### PR TITLE
feat: dns resolver option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@govtechsg/dnsprove": "^2.6.2",
+        "@govtechsg/dnsprove": "^2.8.0",
         "@govtechsg/open-attestation": "^6.9.0",
         "axios": "^1.6.2",
         "debug": "^4.3.1",
@@ -3355,13 +3355,13 @@
       }
     },
     "node_modules/@govtechsg/dnsprove": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.6.2.tgz",
-      "integrity": "sha512-BVqvHAvUg863a7F29oT1TVYAWsXHztlaxAlRmRunStbsmPYaw9CNasE7PUDxfJ8V8fL5J1smqJ6SCdxBmAG0+w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.8.0.tgz",
+      "integrity": "sha512-QfusJBiKnw1kdOEAW1TgdwpU29Fq1sEwtWWz8UkgkZJbqZJE9cm6mraah3VoDCTe2ljzJd/Tjx0sC2zl421cJQ==",
       "dependencies": {
-        "axios": "^1.6.1",
+        "axios": "^1.6.3",
         "debug": "^4.3.1",
-        "runtypes": "^6.3.0"
+        "runtypes": "^6.7.0"
       }
     },
     "node_modules/@govtechsg/document-store-ethers-v5": {
@@ -5819,11 +5819,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -9400,9 +9400,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@govtechsg/dnsprove": "^2.6.2",
+    "@govtechsg/dnsprove": "^2.8.0",
     "@govtechsg/open-attestation": "^6.9.0",
     "axios": "^1.6.2",
     "debug": "^4.3.1",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -40,7 +40,7 @@ export const getDefaultProvider = (options: VerificationBuilderOptionsWithNetwor
 
 // getProvider is a function to get an existing provider or to get a Default provider, when given the options
 export const getProvider = (options: VerificationBuilderOptions): providers.Provider => {
-  return options.provider ?? getDefaultProvider(options);
+  return options.provider ?? getDefaultProvider(options as VerificationBuilderOptionsWithNetwork);
 };
 
 /**

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,4 +1,5 @@
 import { SignedWrappedDocument, v2, v3, WrappedDocument } from "@govtechsg/open-attestation";
+import type { CustomDnsResolver } from "@govtechsg/dnsprove";
 import { Resolver } from "did-resolver";
 import { providers } from "ethers";
 import { Reason } from "./error";
@@ -8,23 +9,36 @@ import { Reason } from "./error";
  */
 export type PromiseCallback = (promises: Promise<VerificationFragment>[]) => void;
 
-export interface VerificationBuilderOptionsWithProvider {
+export type CustomDnsResolverOption = {
+  dnsResolvers?: CustomDnsResolver[];
+};
+
+export type VerificationBuilderOptionsWithProvider = {
   provider: providers.Provider;
   resolver?: Resolver;
-}
+} & CustomDnsResolverOption;
 
-export interface VerificationBuilderOptionsWithNetwork {
+export type VerificationBuilderOptionsWithNetwork = {
   network: string;
   resolver?: Resolver;
   provider?: never;
-}
+} & CustomDnsResolverOption;
 
-export type VerificationBuilderOptions = VerificationBuilderOptionsWithProvider | VerificationBuilderOptionsWithNetwork;
+export type VerificationBuilderOptionsDnsDid = {
+  resolver?: Resolver;
+  network?: never;
+  provider?: never;
+} & CustomDnsResolverOption;
 
-export interface VerifierOptions {
+export type VerificationBuilderOptions =
+  | VerificationBuilderOptionsWithProvider
+  | VerificationBuilderOptionsWithNetwork
+  | VerificationBuilderOptionsDnsDid;
+
+export type VerifierOptions = {
   provider: providers.Provider;
   resolver?: Resolver;
-}
+} & CustomDnsResolverOption;
 
 /**
  * A verification fragment is the result of a verification

--- a/src/verifiers/issuerIdentity/dnsTxt/openAttestationDnsTxt.ts
+++ b/src/verifiers/issuerIdentity/dnsTxt/openAttestationDnsTxt.ts
@@ -28,7 +28,7 @@ const resolveIssuerIdentity = async (
   options: VerifierOptions
 ): Promise<DnsTxtVerificationStatus> => {
   const network = await options.provider.getNetwork();
-  const records = await getDocumentStoreRecords(location);
+  const records = await getDocumentStoreRecords(location, options.dnsResolvers);
   const matchingRecord = records.find(
     (record) =>
       record.addr.toLowerCase() === smartContractAddress.toLowerCase() &&

--- a/src/verifiers/verificationBuilder.ts
+++ b/src/verifiers/verificationBuilder.ts
@@ -32,6 +32,7 @@ export const verificationBuilder =
     const verifierOptions: VerifierOptions = {
       provider: getProvider(builderOptions),
       resolver: builderOptions.resolver,
+      dnsResolvers: builderOptions.dnsResolvers,
     };
     const promises = verifiers.map((verifier) => {
       if (verifier.test(document, verifierOptions)) {


### PR DESCRIPTION
## Summary

This PR allows users to specify custom DNS resolvers in the verification builder.

Note: This merges with `master` branch

## Changes

- Add a `dnsResolvers` option to the verification builder

## Issues

- `Gitlab issue link` (I can't access it, will add it after I can access it again)
