### PR TITLE
fix: update doc store

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,4 @@ module.exports = {
   moduleNameMapper: {
     axios: "axios/dist/node/axios.cjs", // Temporary workaround: Force Jest to import the CommonJS Axios build
   },
-  transformIgnorePatterns: ["node_modules/(?!(@govtechsg/document-store-ethers-v5)/)"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-conventional": "^18.4.3",
         "@commitlint/prompt": "^18.4.3",
-        "@govtechsg/document-store-ethers-v5": "^4.0.0",
+        "@govtechsg/document-store-ethers-v5": "^4.1.0",
         "@snyk/protect": "^1.1257.0",
         "@types/debug": "^4.1.5",
         "@types/jest": "^27.5.2",
@@ -3544,9 +3544,9 @@
       }
     },
     "node_modules/@govtechsg/document-store-ethers-v5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/document-store-ethers-v5/-/document-store-ethers-v5-4.0.0.tgz",
-      "integrity": "sha512-kw7MXwLneBJzWjIqo7juhRhAN9+g9g3qoH0XyKOsVluUHPApOIy/X4ZtaSyEngPq18oWkZEHcU7kOR/z4teXgQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/document-store-ethers-v5/-/document-store-ethers-v5-4.1.0.tgz",
+      "integrity": "sha512-GYr8lfAOcsPanu7TZhRY+cb2OdgOeawlbwL+QSgedt/ghwxLphI3J/dYA/p6htUt/qEmCcbRh39LDM93NSh1gg==",
       "dev": true
     },
     "node_modules/@govtechsg/jsonld": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
     "@commitlint/prompt": "^18.4.3",
-    "@govtechsg/document-store-ethers-v5": "^4.0.0",
+    "@govtechsg/document-store-ethers-v5": "^4.1.0",
     "@snyk/protect": "^1.1257.0",
     "@types/debug": "^4.1.5",
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
## Summary

Update the document store package to use the bundled version.

Note: This merges into beta.

## Changes

- Update document store to v4.1.0

## Issues

- https://sgts.gitlab-dedicated.com/wog/gvt/gds-ace/general/dlt/galaxies-stories/trustdocs-stories/-/issues/313
