### PR TITLE
fix: force microbundler to inline and transpile ethr-did-resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "debug": "^4.3.1",
         "did-resolver": "^4.1.0",
         "ethers": "^5.7.2",
-        "ethr-did-resolver": "^8.1.2",
         "node-cache": "^5.1.2",
         "runtypes": "^6.3.0",
         "web-did-resolver": "^2.0.27"
@@ -37,6 +36,7 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-prettier": "^3.4.0",
+        "ethr-did-resolver": "^8.1.2",
         "git-cz": "^4.9.0",
         "husky": "^8.0.3",
         "jest": "^26.6.3",
@@ -8859,6 +8859,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-8.1.2.tgz",
       "integrity": "sha512-dnbE3GItE1YHp/eavR11KbGDi8Il01H9GeH+wKgoSgE95pKBZufHyHYce/EK2k8VOmj6MJf8u/TIpPvxjCbK+A==",
+      "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.6.3",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -14554,7 +14555,6 @@
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "6.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14566,7 +14566,6 @@
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16569,18 +16568,15 @@
       }
     },
     "node_modules/npm/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs": {
@@ -16597,6 +16593,15 @@
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
       "inBundle": true,
@@ -16803,17 +16808,17 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -16873,6 +16878,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -16894,6 +16923,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14555,6 +14555,7 @@
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "6.0.1",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14566,6 +14567,7 @@
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16568,15 +16570,18 @@
       }
     },
     "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
+      "version": "7.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs": {
@@ -16593,15 +16598,6 @@
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
       "inBundle": true,
@@ -16808,17 +16804,17 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "7.0.0",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -16878,30 +16874,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -16923,18 +16895,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "debug": "^4.3.1",
     "did-resolver": "^4.1.0",
     "ethers": "^5.7.2",
-    "ethr-did-resolver": "^8.1.2",
     "node-cache": "^5.1.2",
     "runtypes": "^6.3.0",
     "web-did-resolver": "^2.0.27"
@@ -57,6 +56,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.4.0",
+    "ethr-did-resolver": "^8.1.2",
     "git-cz": "^4.9.0",
     "husky": "^8.0.3",
     "jest": "^26.6.3",


### PR DESCRIPTION
## Why
The ESM build of `ethr-did-resolver` seems to be mixing cjs, which will fail in esm only environments. Something like that https://github.com/decentralized-identity/ethr-did-resolver/issues/186.

## What
Ideally `ethr-did-resolver` should be rebuilt to only contain ESM code, but since we have no control over that and I do not want to fork them, we can inline the code directly during bundling, this is done by shifting `ethr-did-resolver` to dev deps (a microbundler behaviour).