### PR TITLE
feat: add support for ocsp reason code suspended

### DIFF
--- a/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
+++ b/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../types/core";
 import { Reason } from "../../../types/error";
 import {
+  OcspResponderRevocationReason,
   RevocationStatus,
   RevocationStatusArray,
   ValidRevocationStatus,
@@ -40,7 +41,7 @@ export type DidSignedIssuanceStatusArray = Static<typeof DidSignedIssuanceStatus
  * OCSP response
  */
 
-export const ValidOcspReasonCode = Number.withConstraint((n) => [1, 2, 3, 4, 5, 6, 8, 9, 10, 1001].includes(n));
+export const ValidOcspReasonCode = Number.withConstraint((n) => Object.values(OcspResponderRevocationReason).includes(n));
 
 export const ValidOcspResponse = Record({
   revoked: Literal(false),

--- a/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
+++ b/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
@@ -40,7 +40,7 @@ export type DidSignedIssuanceStatusArray = Static<typeof DidSignedIssuanceStatus
  * OCSP response
  */
 
-export const ValidOcspReasonCode = Number.withConstraint((n) => n >= 0 && n <= 10 && n != 7);
+export const ValidOcspReasonCode = Number.withConstraint((n) => [1, 2, 3, 4, 5, 6, 8, 9, 10, 1001].includes(n));
 
 export const ValidOcspResponse = Record({
   revoked: Literal(false),

--- a/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
+++ b/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.type.ts
@@ -41,7 +41,9 @@ export type DidSignedIssuanceStatusArray = Static<typeof DidSignedIssuanceStatus
  * OCSP response
  */
 
-export const ValidOcspReasonCode = Number.withConstraint((n) => Object.values(OcspResponderRevocationReason).includes(n));
+export const ValidOcspReasonCode = Number.withConstraint((n) =>
+  Object.values(OcspResponderRevocationReason).includes(n)
+);
 
 export const ValidOcspResponse = Record({
   revoked: Literal(false),

--- a/src/verifiers/documentStatus/revocation.types.ts
+++ b/src/verifiers/documentStatus/revocation.types.ts
@@ -32,4 +32,5 @@ export enum OcspResponderRevocationReason {
   REMOVE_FROM_CRL = 8,
   PRIVILEGE_WITHDRAWN = 9,
   A_A_COMPROMISE = 10,
+  SUSPENDED = 1001,
 }


### PR DESCRIPTION
## Summary
To support the [new reason code](https://github.com/Open-Attestation/ocsp-responder/pull/21) `1001` which represents the `suspended` document status on [OCSP responder](https://github.com/Open-Attestation/ocsp-responder)

## Changes

- update `ValidOcspReasonCode` to validate reason code `1001`
- update `OcspResponderRevocationReason` to return `SUSPENDED` for reason code `1001`
- Add test cases for these updates